### PR TITLE
feat: migrate User and Menu entities to MongoDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
             <version>0.12.5</version>

--- a/src/main/java/io/sci/nnfl/api/UserApiController.java
+++ b/src/main/java/io/sci/nnfl/api/UserApiController.java
@@ -24,7 +24,7 @@ public class UserApiController extends BaseApiController {
             }
 
             String userId = getUserId(token);
-            User user = userService.getById(Long.parseLong(userId));
+            User user = userService.getById(userId);
             userService.changePassword(user, request.getCurrentPassword(), request.getNewPassword());
             return getHttpStatus(new Response(user));
 
@@ -42,7 +42,7 @@ public class UserApiController extends BaseApiController {
             }
 
             String userId = getUserId(token);
-            User user = userService.getById(Long.parseLong(userId));
+            User user = userService.getById(userId);
             user = userService.updateProfile(user, request);
             return getHttpStatus(new Response(user));
 

--- a/src/main/java/io/sci/nnfl/model/User.java
+++ b/src/main/java/io/sci/nnfl/model/User.java
@@ -1,51 +1,47 @@
 package io.sci.nnfl.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
-@Entity
-@Table(name = "user",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_users_username", columnNames = "username"),
-                @UniqueConstraint(name = "uk_users_email", columnNames = "email")
-        })
+/**
+ * MongoDB representation of application users.
+ */
+@Document(collection = "user")
 public class User {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @Column(nullable = false, length = 64)
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
     private String username;
 
-    @Column(nullable = false, length = 120)
     private String fullName;
 
-    @Column(nullable = false, length = 160)
+    @Indexed(unique = true)
     private String email;
 
     @JsonIgnore
-    @Column(nullable = false, length = 255)
     private String passwordHash;         // store encoded password
 
     @JsonIgnore
     private boolean enabled = true;
 
     @JsonIgnore
-    @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
-    @Column(name = "role")
     private Set<String> roles = new LinkedHashSet<>();
 
     @JsonIgnore
-    @Column(nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
 
     // getters/setters
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
     public String getUsername() { return username; }
     public void setUsername(String username) { this.username = username; }
     public String getFullName() { return fullName; }
@@ -78,3 +74,4 @@ public class User {
         return Objects.hashCode(id);
     }
 }
+

--- a/src/main/java/io/sci/nnfl/model/dto/MenuRequest.java
+++ b/src/main/java/io/sci/nnfl/model/dto/MenuRequest.java
@@ -21,7 +21,7 @@ public class MenuRequest {
 
     private boolean enabled = true;
 
-    private Long parentId; // nullable
+    private String parentId; // nullable
 
     // CSV roles in the form; convert to set
     private String rolesCsv;
@@ -37,8 +37,8 @@ public class MenuRequest {
     public void setOrderIndex(Integer orderIndex) { this.orderIndex = orderIndex; }
     public boolean isEnabled() { return enabled; }
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
-    public Long getParentId() { return parentId; }
-    public void setParentId(Long parentId) { this.parentId = parentId; }
+    public String getParentId() { return parentId; }
+    public void setParentId(String parentId) { this.parentId = parentId; }
     public String getRolesCsv() { return rolesCsv; }
     public void setRolesCsv(String rolesCsv) { this.rolesCsv = rolesCsv; }
 
@@ -58,7 +58,7 @@ public class MenuRequest {
         r.setIcon(e.getIcon());
         r.setOrderIndex(e.getOrderIndex());
         r.setEnabled(e.isEnabled());
-        r.setParentId(e.getParent() != null ? e.getParent().getId() : null);
+        r.setParentId(e.getParentId());
         r.setRolesCsv(String.join(", ", e.getRequiredRoles()));
         return r;
     }

--- a/src/main/java/io/sci/nnfl/model/dto/UserRequest.java
+++ b/src/main/java/io/sci/nnfl/model/dto/UserRequest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 public class UserRequest {
 
-    private Long id;
+    private String id;
     @NotBlank @Size(max = 64)
     private String username;
 
@@ -30,11 +30,11 @@ public class UserRequest {
     // CSV roles, e.g.: "ADMIN, USER"
     private String rolesCsv;
 
-    public Long getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/src/main/java/io/sci/nnfl/model/repository/MaterialRecordRepository.java
+++ b/src/main/java/io/sci/nnfl/model/repository/MaterialRecordRepository.java
@@ -1,0 +1,11 @@
+package io.sci.nnfl.model.repository;
+
+import io.sci.nnfl.model.MaterialRecord;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+/**
+ * Repository for {@link MaterialRecord} documents.
+ */
+public interface MaterialRecordRepository extends MongoRepository<MaterialRecord, String> {
+}
+

--- a/src/main/java/io/sci/nnfl/model/repository/MenuRepository.java
+++ b/src/main/java/io/sci/nnfl/model/repository/MenuRepository.java
@@ -1,11 +1,12 @@
 package io.sci.nnfl.model.repository;
 
 import io.sci.nnfl.model.Menu;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
 import java.util.List;
 
-public interface MenuRepository extends JpaRepository<Menu, Long> {
-    List<Menu> findAllByParentIsNullOrderByOrderIndexAscTitleAsc();
-    List<Menu> findAllByParentOrderByOrderIndexAscTitleAsc(Menu parent);
+public interface MenuRepository extends MongoRepository<Menu, String> {
+    List<Menu> findAllByParentIdIsNullOrderByOrderIndexAscTitleAsc();
+    List<Menu> findAllByParentIdOrderByOrderIndexAscTitleAsc(String parentId);
     List<Menu> findAllByOrderByParentIdAscOrderIndexAscTitleAsc();
 }

--- a/src/main/java/io/sci/nnfl/model/repository/UserRepository.java
+++ b/src/main/java/io/sci/nnfl/model/repository/UserRepository.java
@@ -1,11 +1,11 @@
 package io.sci.nnfl.model.repository;
 
 import io.sci.nnfl.model.User;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends MongoRepository<User, String> {
     Optional<User> findByUsername(String username);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);

--- a/src/main/java/io/sci/nnfl/service/UserService.java
+++ b/src/main/java/io/sci/nnfl/service/UserService.java
@@ -29,7 +29,7 @@ public class UserService extends BaseService {
     }
 
     @Transactional(readOnly = true)
-    public User getById(Long id) {
+    public User getById(String id) {
         return userRepo.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -67,7 +67,7 @@ public class UserService extends BaseService {
     }
 
     @Transactional
-    public User update(Long id, UserRequest req) {
+    public User update(String id, UserRequest req) {
         var u = getById(id);
         u.setUsername(req.getUsername().trim());
         u.setFullName(req.getFullName().trim());

--- a/src/main/java/io/sci/nnfl/web/MenuController.java
+++ b/src/main/java/io/sci/nnfl/web/MenuController.java
@@ -45,7 +45,7 @@ public class MenuController {
     }
 
     @GetMapping("/{id}/edit")
-    public String editForm(@PathVariable("id") Long id, Model model) {
+    public String editForm(@PathVariable("id") String id, Model model) {
         var entity = service.getById(id);
         model.addAttribute("menuId", id);
         model.addAttribute("menu", MenuRequest.fromEntity(entity));
@@ -54,7 +54,7 @@ public class MenuController {
     }
 
     @PostMapping("/{id}")
-    public String update(@PathVariable("id") Long id,
+    public String update(@PathVariable("id") String id,
                          @Valid @ModelAttribute("menu") MenuRequest form,
                          BindingResult binding,
                          RedirectAttributes ra,
@@ -70,7 +70,7 @@ public class MenuController {
     }
 
     @PostMapping("/{id}/delete")
-    public String delete(@PathVariable("id") Long id, RedirectAttributes ra) {
+    public String delete(@PathVariable("id") String id, RedirectAttributes ra) {
         service.delete(id);
         ra.addFlashAttribute("success", "Menu item deleted.");
         return "redirect:/admin/menu";

--- a/src/main/java/io/sci/nnfl/web/UserAdminController.java
+++ b/src/main/java/io/sci/nnfl/web/UserAdminController.java
@@ -21,7 +21,7 @@ public class UserAdminController {
     }
 
     @GetMapping
-    public String list(@RequestParam(name = "userId", required = false) Long userId,
+    public String list(@RequestParam(name = "userId", required = false) String userId,
                        Model model) {
         UserRequest form = new UserRequest();
         if(userId!=null) {
@@ -69,12 +69,12 @@ public class UserAdminController {
     }
 
     @GetMapping("/{id}/edit")
-    public String editForm(@PathVariable("id") Long id) {
+    public String editForm(@PathVariable("id") String id) {
         return "redirect:/admin/users?userId="+id;
     }
 
     @PostMapping("/{id}")
-    public String update(@PathVariable("id") Long id,
+    public String update(@PathVariable("id") String id,
                          @Valid @ModelAttribute("user") UserRequest form,
                          BindingResult binding,
                          RedirectAttributes ra,


### PR DESCRIPTION
## Summary
- add Spring Data MongoDB dependency
- refactor User and Menu entities for MongoDB with string ids
- migrate repositories and services to MongoRepository and add MaterialRecordRepository

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c37b9c3b00833381d3375031a8f7d7