### PR TITLE
feat: extend material form with property cards and dialogs

### DIFF
--- a/src/main/java/io/sci/nnfl/model/MaterialProperty.java
+++ b/src/main/java/io/sci/nnfl/model/MaterialProperty.java
@@ -1,0 +1,22 @@
+package io.sci.nnfl.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(collection = "material_properties")
+public class MaterialProperty {
+    @Id
+    private String id;
+    private String type;
+    private List<String> values;
+}

--- a/src/main/java/io/sci/nnfl/model/repository/MaterialPropertyRepository.java
+++ b/src/main/java/io/sci/nnfl/model/repository/MaterialPropertyRepository.java
@@ -1,0 +1,10 @@
+package io.sci.nnfl.model.repository;
+
+import io.sci.nnfl.model.MaterialProperty;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+/**
+ * Repository for material property entries.
+ */
+public interface MaterialPropertyRepository extends MongoRepository<MaterialProperty, String> {
+}

--- a/src/main/java/io/sci/nnfl/service/MaterialRecordService.java
+++ b/src/main/java/io/sci/nnfl/service/MaterialRecordService.java
@@ -2,6 +2,8 @@ package io.sci.nnfl.service;
 
 import io.sci.nnfl.model.MaterialRecord;
 import io.sci.nnfl.model.repository.MaterialRecordRepository;
+import io.sci.nnfl.model.repository.MaterialPropertyRepository;
+import io.sci.nnfl.model.MaterialProperty;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -15,9 +17,12 @@ import java.util.List;
 public class MaterialRecordService extends BaseService {
 
     private final MaterialRecordRepository repository;
+    private final MaterialPropertyRepository propertyRepository;
 
-    public MaterialRecordService(MaterialRecordRepository repository) {
+    public MaterialRecordService(MaterialRecordRepository repository,
+                                 MaterialPropertyRepository propertyRepository) {
         this.repository = repository;
+        this.propertyRepository = propertyRepository;
     }
 
     @Transactional(readOnly = true)
@@ -39,5 +44,14 @@ public class MaterialRecordService extends BaseService {
     @Transactional
     public void delete(String id) {
         repository.deleteById(id);
+    }
+
+    @Transactional
+    public void saveProperty(String type, java.util.List<String> values) {
+        MaterialProperty property = MaterialProperty.builder()
+                .type(type)
+                .values(values)
+                .build();
+        propertyRepository.save(property);
     }
 }

--- a/src/main/java/io/sci/nnfl/web/MaterialRecordController.java
+++ b/src/main/java/io/sci/nnfl/web/MaterialRecordController.java
@@ -79,4 +79,11 @@ public class MaterialRecordController {
         ra.addFlashAttribute("materialSaved", true);
         return "redirect:/materials";
     }
+
+    @PostMapping("/{property}")
+    @ResponseBody
+    public void saveProperty(@PathVariable("property") String property,
+                             @RequestBody java.util.List<String> values) {
+        service.saveProperty(property, values);
+    }
 }

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -105,6 +105,203 @@
                 </div>
             </div>
         </div>
+        <!-- Container -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Container</h3>
+                <button type="button" id="addContainer" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="containerTable" class="table w-full">
+                        <thead>
+                        <tr><th>Type</th><th>Volume</th><th>Serial Number</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- General Info -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">General Info</h3>
+                <button type="button" id="addGeneralInfo" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="generalInfoTable" class="table w-full">
+                        <thead>
+                        <tr><th>Custodian</th><th>Analytical Lab</th><th>Country</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Geology -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Geology</h3>
+                <button type="button" id="addGeology" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="geologyTable" class="table w-full">
+                        <thead>
+                        <tr><th>Mine Location</th><th>Formation</th><th>Deposit Types</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Irradiation History -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Irradiation History</h3>
+                <button type="button" id="addIrradiation" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="irradiationTable" class="table w-full">
+                        <thead>
+                        <tr><th>Reactor Type</th><th>Burn Up</th><th>Load Date</th><th>Discharge Date</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Isotope Activity -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Isotope Activity</h3>
+                <button type="button" id="addIsotopeActivity" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="isotopeActivityTable" class="table w-full">
+                        <thead>
+                        <tr><th>Isotope</th><th>Activity (Bq)</th><th>Reference Date</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Mineralogy -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Mineralogy</h3>
+                <button type="button" id="addMineralogy" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="mineralogyTable" class="table w-full">
+                        <thead>
+                        <tr><th>Minerals Present</th><th>Volume %</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Physical -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Physical</h3>
+                <button type="button" id="addPhysical" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="physicalTable" class="table w-full">
+                        <thead>
+                        <tr><th>State</th><th>Description</th><th>Mass</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Process Information -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Process Information</h3>
+                <button type="button" id="addProcessInfo" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="processInfoTable" class="table w-full">
+                        <thead>
+                        <tr><th>Process Type</th><th>Location</th><th>Start Date</th><th>End Date</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Serial Number -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Serial Number</h3>
+                <button type="button" id="addSerialNumber" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="serialNumberTable" class="table w-full">
+                        <thead>
+                        <tr><th>Serial Number</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Source Activity Info -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Source Activity Info</h3>
+                <button type="button" id="addSourceActivityInfo" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="sourceActivityInfoTable" class="table w-full">
+                        <thead>
+                        <tr><th>Activity (Bq)</th><th>Reference Date</th><th>Neutron Intensity</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Source Description -->
+        <div class="kt-card">
+            <div class="kt-card-header flex justify-between">
+                <h3 class="kt-card-title">Source Description</h3>
+                <button type="button" id="addSourceDescription" class="kt-btn kt-btn-light">Add</button>
+            </div>
+            <div class="kt-card-content">
+                <div class="table-responsive">
+                    <table id="sourceDescriptionTable" class="table w-full">
+                        <thead>
+                        <tr><th>Source Type</th><th>Quantity</th><th>Serial Number</th><th>Notes</th><th>Actions</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -226,6 +423,276 @@
         <div class="flex justify-end gap-2">
             <button type="button" id="saveDecay" class="kt-btn kt-btn-primary">Save</button>
             <button type="button" class="kt-btn" onclick="$('#decayDialog').dialog('close');">Cancel</button>
+</div>
+</div>
+
+<div id="containerDialog" title="Edit Container" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Type :</label>
+            <input class="kt-input" id="containerType" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Volume :</label>
+            <input class="kt-input" id="containerVolume" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Serial Number :</label>
+            <input class="kt-input" id="containerSerial" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="containerNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveContainer" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#containerDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="generalInfoDialog" title="Edit General Info" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Custodian :</label>
+            <input class="kt-input" id="generalCustodian" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Analytical Lab :</label>
+            <input class="kt-input" id="generalLab" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Country :</label>
+            <input class="kt-input" id="generalCountry" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="generalNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveGeneralInfo" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#generalInfoDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="geologyDialog" title="Edit Geology" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Mine Location :</label>
+            <input class="kt-input" id="geologyLocation" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Formation :</label>
+            <input class="kt-input" id="geologyFormation" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Deposit Types :</label>
+            <input class="kt-input" id="geologyDeposit" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="geologyNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveGeology" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#geologyDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="irradiationDialog" title="Edit Irradiation History" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Reactor Type :</label>
+            <input class="kt-input" id="irradiationReactor" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Burn Up :</label>
+            <input class="kt-input" id="irradiationBurnUp" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Load Date :</label>
+            <input class="kt-input" id="irradiationLoadDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Discharge Date :</label>
+            <input class="kt-input" id="irradiationDischargeDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="irradiationNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveIrradiation" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#irradiationDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="isotopeActivityDialog" title="Edit Isotope Activity" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Isotope :</label>
+            <input class="kt-input" id="isotopeActivityName" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Activity (Bq) :</label>
+            <input class="kt-input" id="isotopeActivityValue" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Reference Date :</label>
+            <input class="kt-input" id="isotopeActivityDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="isotopeActivityNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveIsotopeActivity" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#isotopeActivityDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="mineralogyDialog" title="Edit Mineralogy" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Minerals Present :</label>
+            <input class="kt-input" id="mineralogyMinerals" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Volume % :</label>
+            <input class="kt-input" id="mineralogyVolume" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="mineralogyNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveMineralogy" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#mineralogyDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="physicalDialog" title="Edit Physical" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">State :</label>
+            <input class="kt-input" id="physicalState" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Description :</label>
+            <input class="kt-input" id="physicalDescription" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Mass :</label>
+            <input class="kt-input" id="physicalMass" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="physicalNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="savePhysical" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#physicalDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="processInfoDialog" title="Edit Process Information" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Process Type :</label>
+            <input class="kt-input" id="processType" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Location :</label>
+            <input class="kt-input" id="processLocation" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Start Date :</label>
+            <input class="kt-input" id="processStart" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">End Date :</label>
+            <input class="kt-input" id="processEnd" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="processNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveProcessInfo" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#processInfoDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="serialNumberDialog" title="Edit Serial Number" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Serial Number :</label>
+            <input class="kt-input" id="serialNumberValue" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="serialNumberNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveSerialNumber" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#serialNumberDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="sourceActivityInfoDialog" title="Edit Source Activity Info" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Activity (Bq) :</label>
+            <input class="kt-input" id="sourceActivityValue" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Reference Date :</label>
+            <input class="kt-input" id="sourceActivityDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Neutron Intensity :</label>
+            <input class="kt-input" id="sourceActivityNeutron" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="sourceActivityNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveSourceActivityInfo" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#sourceActivityInfoDialog').dialog('close');">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="sourceDescriptionDialog" title="Edit Source Description" style="display:none;">
+    <div class="grid gap-5">
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Source Type :</label>
+            <input class="kt-input" id="sourceDescriptionType" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Quantity :</label>
+            <input class="kt-input" id="sourceDescriptionQuantity" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Serial Number :</label>
+            <input class="kt-input" id="sourceDescriptionSerial" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="sourceDescriptionNotes" type="text"/>
+        </div>
+        <div class="flex justify-end gap-2">
+            <button type="button" id="saveSourceDescription" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#sourceDescriptionDialog').dialog('close');">Cancel</button>
         </div>
     </div>
 </div>
@@ -246,6 +713,31 @@
                 $(dialogId + ' input').val('');
             });
         }
+
+        function initEditableDialog(dialogId, addBtnId, saveBtnId, tableId, getData, setData, endpoint){
+            var currentRow = null;
+            $(dialogId).dialog({ autoOpen:false, modal:true, width:400 });
+            $(addBtnId).click(function(){ currentRow=null; $(dialogId).dialog('open'); });
+            $(tableId).on('click','.editRow', function(){
+                currentRow = $(this).closest('tr');
+                var values = currentRow.children('td').slice(0,-1).map(function(){ return $(this).text(); }).get();
+                setData(values);
+                $(dialogId).dialog('open');
+            });
+            $(saveBtnId).click(function(){
+                var data = getData();
+                var row = data.map(function(d){ return '<td>'+d+'</td>'; }).join('') + '<td><button type="button" class="editRow">Edit</button></td>';
+                if(currentRow){
+                    currentRow.html(row);
+                } else {
+                    $(tableId+' tbody').append('<tr>'+row+'</tr>');
+                }
+                fetch(endpoint, {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(data)});
+                $(dialogId).dialog('close');
+                $(dialogId + ' input').val('');
+                currentRow=null;
+            });
+        }
         initDialog('#chemicalDialog','#addChemical','#saveChemical','#chemicalTable', function(){
             return [$('#chemicalName').val(), $('#chemicalDeviation').val(), $('#chemicalComment').val()];
         });
@@ -261,6 +753,72 @@
         initDialog('#decayDialog','#addDecay','#saveDecay','#decayTable', function(){
             return [$('#decayNuclide').val(), $('#decayActivity').val(), $('#decayComment').val()];
         });
+
+        initEditableDialog('#containerDialog','#addContainer','#saveContainer','#containerTable', function(){
+            return [$('#containerType').val(), $('#containerVolume').val(), $('#containerSerial').val(), $('#containerNotes').val()];
+        }, function(v){
+            $('#containerType').val(v[0]); $('#containerVolume').val(v[1]); $('#containerSerial').val(v[2]); $('#containerNotes').val(v[3]);
+        }, '/materials/containers');
+
+        initEditableDialog('#generalInfoDialog','#addGeneralInfo','#saveGeneralInfo','#generalInfoTable', function(){
+            return [$('#generalCustodian').val(), $('#generalLab').val(), $('#generalCountry').val(), $('#generalNotes').val()];
+        }, function(v){
+            $('#generalCustodian').val(v[0]); $('#generalLab').val(v[1]); $('#generalCountry').val(v[2]); $('#generalNotes').val(v[3]);
+        }, '/materials/general-info');
+
+        initEditableDialog('#geologyDialog','#addGeology','#saveGeology','#geologyTable', function(){
+            return [$('#geologyLocation').val(), $('#geologyFormation').val(), $('#geologyDeposit').val(), $('#geologyNotes').val()];
+        }, function(v){
+            $('#geologyLocation').val(v[0]); $('#geologyFormation').val(v[1]); $('#geologyDeposit').val(v[2]); $('#geologyNotes').val(v[3]);
+        }, '/materials/geology');
+
+        initEditableDialog('#irradiationDialog','#addIrradiation','#saveIrradiation','#irradiationTable', function(){
+            return [$('#irradiationReactor').val(), $('#irradiationBurnUp').val(), $('#irradiationLoadDate').val(), $('#irradiationDischargeDate').val(), $('#irradiationNotes').val()];
+        }, function(v){
+            $('#irradiationReactor').val(v[0]); $('#irradiationBurnUp').val(v[1]); $('#irradiationLoadDate').val(v[2]); $('#irradiationDischargeDate').val(v[3]); $('#irradiationNotes').val(v[4]);
+        }, '/materials/irradiation');
+
+        initEditableDialog('#isotopeActivityDialog','#addIsotopeActivity','#saveIsotopeActivity','#isotopeActivityTable', function(){
+            return [$('#isotopeActivityName').val(), $('#isotopeActivityValue').val(), $('#isotopeActivityDate').val(), $('#isotopeActivityNotes').val()];
+        }, function(v){
+            $('#isotopeActivityName').val(v[0]); $('#isotopeActivityValue').val(v[1]); $('#isotopeActivityDate').val(v[2]); $('#isotopeActivityNotes').val(v[3]);
+        }, '/materials/isotope-activity');
+
+        initEditableDialog('#mineralogyDialog','#addMineralogy','#saveMineralogy','#mineralogyTable', function(){
+            return [$('#mineralogyMinerals').val(), $('#mineralogyVolume').val(), $('#mineralogyNotes').val()];
+        }, function(v){
+            $('#mineralogyMinerals').val(v[0]); $('#mineralogyVolume').val(v[1]); $('#mineralogyNotes').val(v[2]);
+        }, '/materials/mineralogy');
+
+        initEditableDialog('#physicalDialog','#addPhysical','#savePhysical','#physicalTable', function(){
+            return [$('#physicalState').val(), $('#physicalDescription').val(), $('#physicalMass').val(), $('#physicalNotes').val()];
+        }, function(v){
+            $('#physicalState').val(v[0]); $('#physicalDescription').val(v[1]); $('#physicalMass').val(v[2]); $('#physicalNotes').val(v[3]);
+        }, '/materials/physical');
+
+        initEditableDialog('#processInfoDialog','#addProcessInfo','#saveProcessInfo','#processInfoTable', function(){
+            return [$('#processType').val(), $('#processLocation').val(), $('#processStart').val(), $('#processEnd').val(), $('#processNotes').val()];
+        }, function(v){
+            $('#processType').val(v[0]); $('#processLocation').val(v[1]); $('#processStart').val(v[2]); $('#processEnd').val(v[3]); $('#processNotes').val(v[4]);
+        }, '/materials/process-info');
+
+        initEditableDialog('#serialNumberDialog','#addSerialNumber','#saveSerialNumber','#serialNumberTable', function(){
+            return [$('#serialNumberValue').val(), $('#serialNumberNotes').val()];
+        }, function(v){
+            $('#serialNumberValue').val(v[0]); $('#serialNumberNotes').val(v[1]);
+        }, '/materials/serial-number');
+
+        initEditableDialog('#sourceActivityInfoDialog','#addSourceActivityInfo','#saveSourceActivityInfo','#sourceActivityInfoTable', function(){
+            return [$('#sourceActivityValue').val(), $('#sourceActivityDate').val(), $('#sourceActivityNeutron').val(), $('#sourceActivityNotes').val()];
+        }, function(v){
+            $('#sourceActivityValue').val(v[0]); $('#sourceActivityDate').val(v[1]); $('#sourceActivityNeutron').val(v[2]); $('#sourceActivityNotes').val(v[3]);
+        }, '/materials/source-activity-info');
+
+        initEditableDialog('#sourceDescriptionDialog','#addSourceDescription','#saveSourceDescription','#sourceDescriptionTable', function(){
+            return [$('#sourceDescriptionType').val(), $('#sourceDescriptionQuantity').val(), $('#sourceDescriptionSerial').val(), $('#sourceDescriptionNotes').val()];
+        }, function(v){
+            $('#sourceDescriptionType').val(v[0]); $('#sourceDescriptionQuantity').val(v[1]); $('#sourceDescriptionSerial').val(v[2]); $('#sourceDescriptionNotes').val(v[3]);
+        }, '/materials/source-description');
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add cards and tables for container, general info, geology, irradiation history, isotope activity, mineralogy, physical, process information, serial number, source activity info and source description
- support add/edit dialogs that persist rows and refresh tables
- persist property rows via `MaterialProperty` and `/materials/{property}` endpoint

## Testing
- `mvn -q -e -f pom.xml test` *(fails: ProjectBuildingException/UnresolvableModelException)*

------
https://chatgpt.com/codex/tasks/task_e_68c3effc6fa48333bda9beeb5413a71b