### PR TITLE
Add card templates and controllers

### DIFF
--- a/src/main/java/io/sci/nnfl/model/Container.java
+++ b/src/main/java/io/sci/nnfl/model/Container.java
@@ -6,12 +6,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Container {
+    @Id
+    private String id;
     private Stage stage;
     private String type;     // e.g., UF6 cylinder type
     private BigDecimal volume;        // SI if used

--- a/src/main/java/io/sci/nnfl/model/Element.java
+++ b/src/main/java/io/sci/nnfl/model/Element.java
@@ -6,14 +6,16 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Element {
-
-    private Stage stage;
+      @Id
+      private String id;
+      private Stage stage;
     private String element;
     private BigDecimal concentration;
     private String unit;

--- a/src/main/java/io/sci/nnfl/model/GeneralInfo.java
+++ b/src/main/java/io/sci/nnfl/model/GeneralInfo.java
@@ -6,11 +6,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import org.springframework.data.annotation.Id;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class GeneralInfo {
+    @Id
+    private String id;
     private Stage stage;
     private LocalDate dataRecordDate;
     private String custodian;

--- a/src/main/java/io/sci/nnfl/model/Geology.java
+++ b/src/main/java/io/sci/nnfl/model/Geology.java
@@ -4,12 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Geology {
+    @Id
+    private String id;
     private Stage stage;
     private String mineLocation;
     private String geologicalFormation;

--- a/src/main/java/io/sci/nnfl/model/IrradiationHistory.java
+++ b/src/main/java/io/sci/nnfl/model/IrradiationHistory.java
@@ -6,12 +6,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class IrradiationHistory {
+    @Id
+    private String id;
     private Stage stage;
     private String reactorType;
     private String burnUp;                 // include actinides/fission products notes

--- a/src/main/java/io/sci/nnfl/model/IsotopeActivity.java
+++ b/src/main/java/io/sci/nnfl/model/IsotopeActivity.java
@@ -7,12 +7,15 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class IsotopeActivity {
+    @Id
+    private String id;
     private Stage stage;
     private String isotopeName;             // major or minor
     private BigDecimal activityBq;

--- a/src/main/java/io/sci/nnfl/model/IsotopeRatio.java
+++ b/src/main/java/io/sci/nnfl/model/IsotopeRatio.java
@@ -6,12 +6,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class IsotopeRatio {
+    @Id
+    private String id;
     private Stage stage;
     private String name;
     private BigDecimal value;

--- a/src/main/java/io/sci/nnfl/model/Mineralogy.java
+++ b/src/main/java/io/sci/nnfl/model/Mineralogy.java
@@ -4,12 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Mineralogy {
+    @Id
+    private String id;
     private Stage stage;
     private String mineralsPresent;      // free text or CSV
     private String mineralChemistry;     // composition notes

--- a/src/main/java/io/sci/nnfl/model/Morphology.java
+++ b/src/main/java/io/sci/nnfl/model/Morphology.java
@@ -4,12 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Morphology {
+    @Id
+    private String id;
     private Stage stage;
     private String latticeStructure;
     private String aspectRatio;

--- a/src/main/java/io/sci/nnfl/model/Physical.java
+++ b/src/main/java/io/sci/nnfl/model/Physical.java
@@ -4,12 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Physical {
+    @Id
+    private String id;
     private Stage stage;
     private Measurement density;
     private String stateOfMatter;           // solid/liquid/gas

--- a/src/main/java/io/sci/nnfl/model/ProcessInformation.java
+++ b/src/main/java/io/sci/nnfl/model/ProcessInformation.java
@@ -6,12 +6,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ProcessInformation {
+    @Id
+    private String id;
     private Stage stage;
     private String processTypeOrDescription;   // milling, fluorination, fab, repro...
     private String locationOfProcessingSite;

--- a/src/main/java/io/sci/nnfl/model/SerialNumber.java
+++ b/src/main/java/io/sci/nnfl/model/SerialNumber.java
@@ -4,12 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class SerialNumber {
+    @Id
+    private String id;
     private Stage stage;
     private String serialNumber;
     private String notes;

--- a/src/main/java/io/sci/nnfl/model/SourceActivityInfo.java
+++ b/src/main/java/io/sci/nnfl/model/SourceActivityInfo.java
@@ -7,12 +7,15 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class SourceActivityInfo {
+    @Id
+    private String id;
     private Stage stage;
     private BigDecimal activityBq;
     private LocalDate referenceDate;

--- a/src/main/java/io/sci/nnfl/model/SourceDescription.java
+++ b/src/main/java/io/sci/nnfl/model/SourceDescription.java
@@ -4,12 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class SourceDescription {
+    @Id
+    private String id;
     private Stage stage;                 // SEALED_SOURCE / UNSEALED_SOURCE
     private String sourceType;           // emission type / intended use
     private String quantity;             // textual or calculated

--- a/src/main/java/io/sci/nnfl/model/UraniumDecaySeriesRadionuclide.java
+++ b/src/main/java/io/sci/nnfl/model/UraniumDecaySeriesRadionuclide.java
@@ -6,12 +6,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UraniumDecaySeriesRadionuclide {
+    @Id
+    private String id;
     private Stage stage;
     private String isotopeName;          // 230Th, 231Pa, 226Ra, ...
     private BigDecimal activityBq;

--- a/src/main/java/io/sci/nnfl/web/ContainerController.java
+++ b/src/main/java/io/sci/nnfl/web/ContainerController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.Container;
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/container")
+public class ContainerController extends BaseController {
+    private final MaterialRecordService service;
+
+    public ContainerController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody Container container) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getContainers() == null) {
+            record.setContainers(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        container.setStage(Stage.values()[stage]);
+        if (container.getId() == null || container.getId().isEmpty()) {
+            container.setId(UUID.randomUUID().toString());
+        }
+        record.getContainers().removeIf(c -> c.getId().equals(container.getId()));
+        record.getContainers().add(container);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "containers", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/DecayController.java
+++ b/src/main/java/io/sci/nnfl/web/DecayController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.model.UraniumDecaySeriesRadionuclide;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/decay")
+public class DecayController extends BaseController {
+    private final MaterialRecordService service;
+
+    public DecayController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody UraniumDecaySeriesRadionuclide decay) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getUraniumDecaySeriesRadionuclides() == null) {
+            record.setUraniumDecaySeriesRadionuclides(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        decay.setStage(Stage.values()[stage]);
+        if (decay.getId() == null || decay.getId().isEmpty()) {
+            decay.setId(UUID.randomUUID().toString());
+        }
+        record.getUraniumDecaySeriesRadionuclides().removeIf(d -> d.getId().equals(decay.getId()));
+        record.getUraniumDecaySeriesRadionuclides().add(decay);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "uraniumDecaySeriesRadionuclides", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/ElementController.java
+++ b/src/main/java/io/sci/nnfl/web/ElementController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.Element;
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/element")
+public class ElementController extends BaseController {
+    private final MaterialRecordService service;
+
+    public ElementController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody Element element) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getElemental() == null) {
+            record.setElemental(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        element.setStage(Stage.values()[stage]);
+        if (element.getId() == null || element.getId().isEmpty()) {
+            element.setId(UUID.randomUUID().toString());
+        }
+        record.getElemental().removeIf(e -> e.getId().equals(element.getId()));
+        record.getElemental().add(element);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "elemental", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/GeneralInfoController.java
+++ b/src/main/java/io/sci/nnfl/web/GeneralInfoController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.GeneralInfo;
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/general-info")
+public class GeneralInfoController extends BaseController {
+    private final MaterialRecordService service;
+
+    public GeneralInfoController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody GeneralInfo info) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getGeneralInfo() == null) {
+            record.setGeneralInfo(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        info.setStage(Stage.values()[stage]);
+        if (info.getId() == null || info.getId().isEmpty()) {
+            info.setId(UUID.randomUUID().toString());
+        }
+        record.getGeneralInfo().removeIf(g -> g.getId().equals(info.getId()));
+        record.getGeneralInfo().add(info);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "generalInfo", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/GeologyController.java
+++ b/src/main/java/io/sci/nnfl/web/GeologyController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.Geology;
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/geology")
+public class GeologyController extends BaseController {
+    private final MaterialRecordService service;
+
+    public GeologyController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody Geology geology) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getGeology() == null) {
+            record.setGeology(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        geology.setStage(Stage.values()[stage]);
+        if (geology.getId() == null || geology.getId().isEmpty()) {
+            geology.setId(UUID.randomUUID().toString());
+        }
+        record.getGeology().removeIf(g -> g.getId().equals(geology.getId()));
+        record.getGeology().add(geology);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "geology", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/IrradiationController.java
+++ b/src/main/java/io/sci/nnfl/web/IrradiationController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.IrradiationHistory;
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/irradiation")
+public class IrradiationController extends BaseController {
+    private final MaterialRecordService service;
+
+    public IrradiationController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody IrradiationHistory irradiation) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getIrradiationHistories() == null) {
+            record.setIrradiationHistories(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        irradiation.setStage(Stage.values()[stage]);
+        if (irradiation.getId() == null || irradiation.getId().isEmpty()) {
+            irradiation.setId(UUID.randomUUID().toString());
+        }
+        record.getIrradiationHistories().removeIf(i -> i.getId().equals(irradiation.getId()));
+        record.getIrradiationHistories().add(irradiation);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "irradiationHistories", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/IsotopeActivityController.java
+++ b/src/main/java/io/sci/nnfl/web/IsotopeActivityController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.IsotopeActivity;
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/isotope-activity")
+public class IsotopeActivityController extends BaseController {
+    private final MaterialRecordService service;
+
+    public IsotopeActivityController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody IsotopeActivity activity) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getIsotopeActivities() == null) {
+            record.setIsotopeActivities(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        activity.setStage(Stage.values()[stage]);
+        if (activity.getId() == null || activity.getId().isEmpty()) {
+            activity.setId(UUID.randomUUID().toString());
+        }
+        record.getIsotopeActivities().removeIf(a -> a.getId().equals(activity.getId()));
+        record.getIsotopeActivities().add(activity);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "isotopeActivities", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/IsotopeController.java
+++ b/src/main/java/io/sci/nnfl/web/IsotopeController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.IsotopeRatio;
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/isotope")
+public class IsotopeController extends BaseController {
+    private final MaterialRecordService service;
+
+    public IsotopeController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody IsotopeRatio isotope) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getUraniumIsotopes() == null) {
+            record.setUraniumIsotopes(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        isotope.setStage(Stage.values()[stage]);
+        if (isotope.getId() == null || isotope.getId().isEmpty()) {
+            isotope.setId(UUID.randomUUID().toString());
+        }
+        record.getUraniumIsotopes().removeIf(i -> i.getId().equals(isotope.getId()));
+        record.getUraniumIsotopes().add(isotope);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "uraniumIsotopes", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/MineralogyController.java
+++ b/src/main/java/io/sci/nnfl/web/MineralogyController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.Mineralogy;
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/mineralogy")
+public class MineralogyController extends BaseController {
+    private final MaterialRecordService service;
+
+    public MineralogyController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody Mineralogy mineralogy) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getMineralogy() == null) {
+            record.setMineralogy(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        mineralogy.setStage(Stage.values()[stage]);
+        if (mineralogy.getId() == null || mineralogy.getId().isEmpty()) {
+            mineralogy.setId(UUID.randomUUID().toString());
+        }
+        record.getMineralogy().removeIf(m -> m.getId().equals(mineralogy.getId()));
+        record.getMineralogy().add(mineralogy);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "mineralogy", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/MorphologyController.java
+++ b/src/main/java/io/sci/nnfl/web/MorphologyController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Morphology;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/morphology")
+public class MorphologyController extends BaseController {
+    private final MaterialRecordService service;
+
+    public MorphologyController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody Morphology morphology) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getMorphologies() == null) {
+            record.setMorphologies(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        morphology.setStage(Stage.values()[stage]);
+        if (morphology.getId() == null || morphology.getId().isEmpty()) {
+            morphology.setId(UUID.randomUUID().toString());
+        }
+        record.getMorphologies().removeIf(m -> m.getId().equals(morphology.getId()));
+        record.getMorphologies().add(morphology);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "morphologies", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/PhysicalController.java
+++ b/src/main/java/io/sci/nnfl/web/PhysicalController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.Physical;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/physical")
+public class PhysicalController extends BaseController {
+    private final MaterialRecordService service;
+
+    public PhysicalController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody Physical physical) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getPhysicals() == null) {
+            record.setPhysicals(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        physical.setStage(Stage.values()[stage]);
+        if (physical.getId() == null || physical.getId().isEmpty()) {
+            physical.setId(UUID.randomUUID().toString());
+        }
+        record.getPhysicals().removeIf(p -> p.getId().equals(physical.getId()));
+        record.getPhysicals().add(physical);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "physicals", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/ProcessInfoController.java
+++ b/src/main/java/io/sci/nnfl/web/ProcessInfoController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.ProcessInformation;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/process-info")
+public class ProcessInfoController extends BaseController {
+    private final MaterialRecordService service;
+
+    public ProcessInfoController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody ProcessInformation info) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getProcessInformation() == null) {
+            record.setProcessInformation(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        info.setStage(Stage.values()[stage]);
+        if (info.getId() == null || info.getId().isEmpty()) {
+            info.setId(UUID.randomUUID().toString());
+        }
+        record.getProcessInformation().removeIf(p -> p.getId().equals(info.getId()));
+        record.getProcessInformation().add(info);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "processInformation", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/SerialNumberController.java
+++ b/src/main/java/io/sci/nnfl/web/SerialNumberController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.SerialNumber;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/serial-number")
+public class SerialNumberController extends BaseController {
+    private final MaterialRecordService service;
+
+    public SerialNumberController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody SerialNumber serial) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getSerialNumbers() == null) {
+            record.setSerialNumbers(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        serial.setStage(Stage.values()[stage]);
+        if (serial.getId() == null || serial.getId().isEmpty()) {
+            serial.setId(UUID.randomUUID().toString());
+        }
+        record.getSerialNumbers().removeIf(s -> s.getId().equals(serial.getId()));
+        record.getSerialNumbers().add(serial);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "serialNumbers", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/SourceActivityInfoController.java
+++ b/src/main/java/io/sci/nnfl/web/SourceActivityInfoController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.SourceActivityInfo;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/source-activity-info")
+public class SourceActivityInfoController extends BaseController {
+    private final MaterialRecordService service;
+
+    public SourceActivityInfoController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody SourceActivityInfo info) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getSourceActivityInfo() == null) {
+            record.setSourceActivityInfo(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        info.setStage(Stage.values()[stage]);
+        if (info.getId() == null || info.getId().isEmpty()) {
+            info.setId(UUID.randomUUID().toString());
+        }
+        record.getSourceActivityInfo().removeIf(s -> s.getId().equals(info.getId()));
+        record.getSourceActivityInfo().add(info);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "sourceActivityInfo", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/java/io/sci/nnfl/web/SourceDescriptionController.java
+++ b/src/main/java/io/sci/nnfl/web/SourceDescriptionController.java
@@ -1,0 +1,55 @@
+package io.sci.nnfl.web;
+
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.model.SourceDescription;
+import io.sci.nnfl.model.Stage;
+import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/source-description")
+public class SourceDescriptionController extends BaseController {
+    private final MaterialRecordService service;
+
+    public SourceDescriptionController(MaterialRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/{materialId}/{stage}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
+                                                    @PathVariable Integer stage,
+                                                    @RequestBody SourceDescription description) {
+        MaterialRecord record = service.getById(materialId);
+        if (record.getSourceDescriptions() == null) {
+            record.setSourceDescriptions(new ArrayList<>());
+        }
+        if (stage == null || stage < 0 || stage >= Stage.values().length) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        description.setStage(Stage.values()[stage]);
+        if (description.getId() == null || description.getId().isEmpty()) {
+            description.setId(UUID.randomUUID().toString());
+        }
+        record.getSourceDescriptions().removeIf(s -> s.getId().equals(description.getId()));
+        record.getSourceDescriptions().add(description);
+        service.save(record);
+        String redirect = "/materials/new/" + materialId + "/" + stage;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    @PostMapping("/{materialId}/{stage}/{id}/delete")
+    public String delete(@PathVariable String materialId,
+                         @PathVariable Integer stage,
+                         @PathVariable String id) {
+        service.removeProperty(materialId, "sourceDescriptions", id);
+        return "redirect:/materials/new/" + materialId + "/" + stage;
+    }
+}
+

--- a/src/main/resources/templates/cards/container.html
+++ b/src/main/resources/templates/cards/container.html
@@ -1,0 +1,41 @@
+<div th:fragment="containerCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Container</h3>
+        <button type="button" id="addContainer" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="containerTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Type</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Volume</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Serial Number</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="container : ${material.containers}">
+                    <tr>
+                        <td><span th:text="${container.type}"></span></td>
+                        <td><span th:text="${container.volume}"></span></td>
+                        <td><span th:text="${container.serialNumber}"></span></td>
+                        <td><span th:text="${container.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/container/${material.id}/${stage}/${container.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/decay.html
+++ b/src/main/resources/templates/cards/decay.html
@@ -1,0 +1,39 @@
+<div th:fragment="decayCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Uranium decays</h3>
+        <button type="button" id="addDecay" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="decayTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Nuclide</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Activity</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="decay : ${material.uraniumDecaySeriesRadionuclides}">
+                    <tr>
+                        <td><span th:text="${decay.isotopeName}"></span></td>
+                        <td><span th:text="${decay.activityBq}"></span></td>
+                        <td><span th:text="${decay.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/decay/${material.id}/${stage}/${decay.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/element.html
+++ b/src/main/resources/templates/cards/element.html
@@ -1,0 +1,41 @@
+<div th:fragment="elementCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Element(s)</h3>
+        <button type="button" id="addElement" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="elementTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Name</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Concentration</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Uncertainty</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="element : ${material.elemental}">
+                    <tr>
+                        <td><span th:text="${element.element}"></span></td>
+                        <td><span th:text="${element.concentration}"></span></td>
+                        <td><span th:text="${element.uncertainty}"></span></td>
+                        <td><span th:text="${element.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/element/${material.id}/${stage}/${element.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/general-info.html
+++ b/src/main/resources/templates/cards/general-info.html
@@ -1,0 +1,41 @@
+<div th:fragment="generalInfoCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">General Info</h3>
+        <button type="button" id="addGeneralInfo" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="generalInfoTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Custodian</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Analytical Lab</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Country</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="info : ${material.generalInfo}">
+                    <tr>
+                        <td><span th:text="${info.custodian}"></span></td>
+                        <td><span th:text="${info.analyticalLab}"></span></td>
+                        <td><span th:text="${info.countryOfOrigin}"></span></td>
+                        <td><span th:text="${info.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/general-info/${material.id}/${stage}/${info.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/geology.html
+++ b/src/main/resources/templates/cards/geology.html
@@ -1,0 +1,41 @@
+<div th:fragment="geologyCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Geology</h3>
+        <button type="button" id="addGeology" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="geologyTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Mine Location</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Formation</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Deposit Types</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="geo : ${material.geology}">
+                    <tr>
+                        <td><span th:text="${geo.mineLocation}"></span></td>
+                        <td><span th:text="${geo.geologicalFormation}"></span></td>
+                        <td><span th:text="${geo.depositTypes}"></span></td>
+                        <td><span th:text="${geo.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/geology/${material.id}/${stage}/${geo.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/irradiation.html
+++ b/src/main/resources/templates/cards/irradiation.html
@@ -1,0 +1,43 @@
+<div th:fragment="irradiationCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Irradiation History</h3>
+        <button type="button" id="addIrradiation" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="irradiationTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Reactor Type</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Burn Up</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Load Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Discharge Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="irr : ${material.irradiationHistories}">
+                    <tr>
+                        <td><span th:text="${irr.reactorType}"></span></td>
+                        <td><span th:text="${irr.burnUp}"></span></td>
+                        <td><span th:text="${irr.loadDate}"></span></td>
+                        <td><span th:text="${irr.dischargeDate}"></span></td>
+                        <td><span th:text="${irr.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/irradiation/${material.id}/${stage}/${irr.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/isotope-activity.html
+++ b/src/main/resources/templates/cards/isotope-activity.html
@@ -1,0 +1,41 @@
+<div th:fragment="isotopeActivityCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Isotope Activity</h3>
+        <button type="button" id="addIsotopeActivity" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="isotopeActivityTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Isotope</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Activity (Bq)</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Reference Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="act : ${material.isotopeActivities}">
+                    <tr>
+                        <td><span th:text="${act.isotopeName}"></span></td>
+                        <td><span th:text="${act.activityBq}"></span></td>
+                        <td><span th:text="${act.referenceDate}"></span></td>
+                        <td><span th:text="${act.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/isotope-activity/${material.id}/${stage}/${act.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/isotope.html
+++ b/src/main/resources/templates/cards/isotope.html
@@ -1,0 +1,41 @@
+<div th:fragment="isotopeCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Isotope(s) ratio</h3>
+        <button type="button" id="addIsotope" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="isotopeTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Isotope Name</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Ratio</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Uncertainty</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="iso : ${material.uraniumIsotopes}">
+                    <tr>
+                        <td><span th:text="${iso.name}"></span></td>
+                        <td><span th:text="${iso.value}"></span></td>
+                        <td><span th:text="${iso.uncertainty}"></span></td>
+                        <td><span th:text="${iso.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/isotope/${material.id}/${stage}/${iso.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/mineralogy.html
+++ b/src/main/resources/templates/cards/mineralogy.html
@@ -1,0 +1,39 @@
+<div th:fragment="mineralogyCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Mineralogy</h3>
+        <button type="button" id="addMineralogy" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="mineralogyTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Minerals Present</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Volume %</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="min : ${material.mineralogy}">
+                    <tr>
+                        <td><span th:text="${min.mineralsPresent}"></span></td>
+                        <td><span th:text="${min.volumePercentages}"></span></td>
+                        <td><span th:text="${min.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/mineralogy/${material.id}/${stage}/${min.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/morphology.html
+++ b/src/main/resources/templates/cards/morphology.html
@@ -1,0 +1,41 @@
+<div th:fragment="morphologyCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Morphology/Crystallography</h3>
+        <button type="button" id="addMorphology" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="morphologyTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Lattice Structure</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Aspect Ratio</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Porosity</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="morph : ${material.morphologies}">
+                    <tr>
+                        <td><span th:text="${morph.latticeStructure}"></span></td>
+                        <td><span th:text="${morph.aspectRatio}"></span></td>
+                        <td><span th:text="${morph.porosity}"></span></td>
+                        <td><span th:text="${morph.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/morphology/${material.id}/${stage}/${morph.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/physical.html
+++ b/src/main/resources/templates/cards/physical.html
@@ -1,0 +1,41 @@
+<div th:fragment="physicalCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Physical</h3>
+        <button type="button" id="addPhysical" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="physicalTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">State</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Description</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Mass</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="phys : ${material.physicals}">
+                    <tr>
+                        <td><span th:text="${phys.stateOfMatter}"></span></td>
+                        <td><span th:text="${phys.description}"></span></td>
+                        <td><span th:text="${phys.mass}"></span></td>
+                        <td><span th:text="${phys.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/physical/${material.id}/${stage}/${phys.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/process-info.html
+++ b/src/main/resources/templates/cards/process-info.html
@@ -1,0 +1,43 @@
+<div th:fragment="processInfoCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Process Information</h3>
+        <button type="button" id="addProcessInfo" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="processInfoTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Process Type</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Location</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Start Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">End Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="proc : ${material.processInformation}">
+                    <tr>
+                        <td><span th:text="${proc.processTypeOrDescription}"></span></td>
+                        <td><span th:text="${proc.locationOfProcessingSite}"></span></td>
+                        <td><span th:text="${proc.startDate}"></span></td>
+                        <td><span th:text="${proc.endDate}"></span></td>
+                        <td><span th:text="${proc.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/process-info/${material.id}/${stage}/${proc.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/serial-number.html
+++ b/src/main/resources/templates/cards/serial-number.html
@@ -1,0 +1,37 @@
+<div th:fragment="serialNumberCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Serial Number</h3>
+        <button type="button" id="addSerialNumber" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="serialNumberTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Serial Number</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="sn : ${material.serialNumbers}">
+                    <tr>
+                        <td><span th:text="${sn.serialNumber}"></span></td>
+                        <td><span th:text="${sn.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/serial-number/${material.id}/${stage}/${sn.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/source-activity-info.html
+++ b/src/main/resources/templates/cards/source-activity-info.html
@@ -1,0 +1,41 @@
+<div th:fragment="sourceActivityInfoCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Source Activity Info</h3>
+        <button type="button" id="addSourceActivityInfo" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="sourceActivityInfoTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Activity (Bq)</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Reference Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Neutron Intensity</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="sai : ${material.sourceActivityInfo}">
+                    <tr>
+                        <td><span th:text="${sai.activityBq}"></span></td>
+                        <td><span th:text="${sai.referenceDate}"></span></td>
+                        <td><span th:text="${sai.neutronIntensityPerSec}"></span></td>
+                        <td><span th:text="${sai.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/source-activity-info/${material.id}/${stage}/${sai.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/src/main/resources/templates/cards/source-description.html
+++ b/src/main/resources/templates/cards/source-description.html
@@ -1,0 +1,41 @@
+<div th:fragment="sourceDescriptionCard" class="kt-card kt-card-grid h-full min-w-full">
+    <div class="kt-card-header flex justify-between">
+        <h3 class="kt-card-title">Source Description</h3>
+        <button type="button" id="addSourceDescription" class="kt-btn kt-btn-light">Add</button>
+    </div>
+    <div class="kt-card-table">
+        <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
+            <div class="kt-scrollable-x-auto">
+                <table id="sourceDescriptionTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                    <thead>
+                    <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Source Type</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Quantity</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Serial Number</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
+                    </tr>
+                    </thead>
+                    <tbody th:each="sd : ${material.sourceDescriptions}">
+                    <tr>
+                        <td><span th:text="${sd.sourceType}"></span></td>
+                        <td><span th:text="${sd.quantity}"></span></td>
+                        <td><span th:text="${sd.serialNumber}"></span></td>
+                        <td><span th:text="${sd.notes}"></span></td>
+                        <td class="flex gap-2">
+                            <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">
+                                <i class="ki-filled ki-notepad-edit"></i>
+                            </button>
+                            <form th:action="@{|/source-description/${material.id}/${stage}/${sd.id}/delete|}" method="post" onsubmit="return confirm('Delete?');">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-trash"></i></button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+


### PR DESCRIPTION
## Summary
- introduce card fragments for material record sections such as general info, containers and isotopes
- implement corresponding controllers to manage each card entry
- add identifier fields to model classes to support CRUD operations

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7819d77348333bffe52e96426b8ad