### PR TITLE
Expand general info form fields

### DIFF
--- a/src/main/resources/templates/cards/general-info.html
+++ b/src/main/resources/templates/cards/general-info.html
@@ -9,18 +9,50 @@
                 <table id="generalInfoTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Data Record Date</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Custodian</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Analytical Lab</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Analysis Date</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Country</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Producer</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Supplier</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Batch ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Batch Process Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Shipper/Carrier</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Receiver Info</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Shipping Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Receiving Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Data Evaluation Info</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Variation Range Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Information Acquisition Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Used Archived Information</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="info : ${material.generalInfo}">
                     <tr>
+                        <td><span th:text="${info.id}"></span></td>
+                        <td><span th:text="${info.stage}"></span></td>
+                        <td><span th:text="${info.dataRecordDate}"></span></td>
                         <td><span th:text="${info.custodian}"></span></td>
                         <td><span th:text="${info.analyticalLab}"></span></td>
+                        <td><span th:text="${info.analysisDate}"></span></td>
                         <td><span th:text="${info.countryOfOrigin}"></span></td>
+                        <td><span th:text="${info.producer}"></span></td>
+                        <td><span th:text="${info.supplier}"></span></td>
+                        <td><span th:text="${info.batchId}"></span></td>
+                        <td><span th:text="${info.batchProcessDate}"></span></td>
+                        <td><span th:text="${info.shipperCarrier}"></span></td>
+                        <td><span th:text="${info.receiverInfo}"></span></td>
+                        <td><span th:text="${info.shippingDate}"></span></td>
+                        <td><span th:text="${info.receivingDate}"></span></td>
+                        <td><span th:text="${info.dataEvaluationInfo}"></span></td>
+                        <td><span th:text="${info.variationRangeNotes}"></span></td>
+                        <td><span th:text="${info.informationAcquisitionDate}"></span></td>
+                        <td><span th:text="${info.usedArchivedInformation}"></span></td>
                         <td><span th:text="${info.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/general-info.html
+++ b/src/main/resources/templates/dialogs/general-info.html
@@ -2,6 +2,14 @@
      id="generalInfoDialog" title="Edit General Info" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="generalId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Data Record Date :</label>
+            <input class="kt-input" id="generalDataRecordDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Custodian :</label>
             <input class="kt-input" id="generalCustodian" type="text"/>
         </div>
@@ -10,8 +18,60 @@
             <input class="kt-input" id="generalLab" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Analysis Date :</label>
+            <input class="kt-input" id="generalAnalysisDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Country :</label>
             <input class="kt-input" id="generalCountry" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Producer :</label>
+            <input class="kt-input" id="generalProducer" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Supplier :</label>
+            <input class="kt-input" id="generalSupplier" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Batch ID :</label>
+            <input class="kt-input" id="generalBatchId" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Batch Process Date :</label>
+            <input class="kt-input" id="generalBatchProcessDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Shipper/Carrier :</label>
+            <input class="kt-input" id="generalShipperCarrier" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Receiver Info :</label>
+            <input class="kt-input" id="generalReceiverInfo" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Shipping Date :</label>
+            <input class="kt-input" id="generalShippingDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Receiving Date :</label>
+            <input class="kt-input" id="generalReceivingDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Data Evaluation Info :</label>
+            <input class="kt-input" id="generalDataEvaluationInfo" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Variation Range Notes :</label>
+            <input class="kt-input" id="generalVariationRangeNotes" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Information Acquisition Date :</label>
+            <input class="kt-input" id="generalInformationAcquisitionDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Used Archived Information :</label>
+            <input class="kt-input" id="generalUsedArchivedInformation" type="checkbox"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Notes :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -197,17 +197,67 @@
         });
 
         init('#generalInfoDialog','#addGeneralInfo','#saveGeneralInfo','#generalInfoTable', function(){
-            return [$('#generalCustodian').val(), $('#generalLab').val(), $('#generalCountry').val(), $('#generalNotes').val()];
+            return [
+                $('#generalId').val(),
+                $('#generalDataRecordDate').val(),
+                $('#generalCustodian').val(),
+                $('#generalLab').val(),
+                $('#generalAnalysisDate').val(),
+                $('#generalCountry').val(),
+                $('#generalProducer').val(),
+                $('#generalSupplier').val(),
+                $('#generalBatchId').val(),
+                $('#generalBatchProcessDate').val(),
+                $('#generalShipperCarrier').val(),
+                $('#generalReceiverInfo').val(),
+                $('#generalShippingDate').val(),
+                $('#generalReceivingDate').val(),
+                $('#generalDataEvaluationInfo').val(),
+                $('#generalVariationRangeNotes').val(),
+                $('#generalInformationAcquisitionDate').val(),
+                $('#generalUsedArchivedInformation').is(':checked'),
+                $('#generalNotes').val()
+            ];
         }, function(v){
-            $('#generalCustodian').val(v[0].trim());
-            $('#generalLab').val(v[1].trim());
-            $('#generalCountry').val(v[2].trim());
-            $('#generalNotes').val(v[3].trim());
+            $('#generalId').val(v[0].trim());
+            $('#generalDataRecordDate').val(v[2].trim());
+            $('#generalCustodian').val(v[3].trim());
+            $('#generalLab').val(v[4].trim());
+            $('#generalAnalysisDate').val(v[5].trim());
+            $('#generalCountry').val(v[6].trim());
+            $('#generalProducer').val(v[7].trim());
+            $('#generalSupplier').val(v[8].trim());
+            $('#generalBatchId').val(v[9].trim());
+            $('#generalBatchProcessDate').val(v[10].trim());
+            $('#generalShipperCarrier').val(v[11].trim());
+            $('#generalReceiverInfo').val(v[12].trim());
+            $('#generalShippingDate').val(v[13].trim());
+            $('#generalReceivingDate').val(v[14].trim());
+            $('#generalDataEvaluationInfo').val(v[15].trim());
+            $('#generalVariationRangeNotes').val(v[16].trim());
+            $('#generalInformationAcquisitionDate').val(v[17].trim());
+            $('#generalUsedArchivedInformation').prop('checked', v[18].trim().toLowerCase() === 'true');
+            $('#generalNotes').val(v[19].trim());
         }, '/general-info/' + materialId + '/' + stage, function(){
             return {
+                id: $('#generalId').val(),
+                dataRecordDate: $('#generalDataRecordDate').val(),
                 custodian: $('#generalCustodian').val(),
                 analyticalLab: $('#generalLab').val(),
+                analysisDate: $('#generalAnalysisDate').val(),
                 countryOfOrigin: $('#generalCountry').val(),
+                producer: $('#generalProducer').val(),
+                supplier: $('#generalSupplier').val(),
+                batchId: $('#generalBatchId').val(),
+                batchProcessDate: $('#generalBatchProcessDate').val(),
+                shipperCarrier: $('#generalShipperCarrier').val(),
+                receiverInfo: $('#generalReceiverInfo').val(),
+                shippingDate: $('#generalShippingDate').val(),
+                receivingDate: $('#generalReceivingDate').val(),
+                dataEvaluationInfo: $('#generalDataEvaluationInfo').val(),
+                variationRangeNotes: $('#generalVariationRangeNotes').val(),
+                informationAcquisitionDate: $('#generalInformationAcquisitionDate').val(),
+                usedArchivedInformation: $('#generalUsedArchivedInformation').is(':checked'),
                 notes: $('#generalNotes').val()
             };
         });


### PR DESCRIPTION
## Summary
- display all GeneralInfo model properties in the general info card and dialog
- update material-form script to handle full GeneralInfo data set

## Testing
- `mvn -e -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c78b3f35a88333a35bb280a6b2c7f9