### PR TITLE
feat: expand mineralogy forms

### DIFF
--- a/src/main/resources/templates/cards/mineralogy.html
+++ b/src/main/resources/templates/cards/mineralogy.html
@@ -9,7 +9,9 @@
                 <table id="mineralogyTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Minerals Present</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Mineral Chemistry</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Volume %</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
@@ -17,7 +19,9 @@
                     </thead>
                     <tbody th:each="min : ${material.mineralogy}">
                     <tr>
+                        <td><span th:text="${min.id}" hidden></span></td>
                         <td><span th:text="${min.mineralsPresent}"></span></td>
+                        <td><span th:text="${min.mineralChemistry}"></span></td>
                         <td><span th:text="${min.volumePercentages}"></span></td>
                         <td><span th:text="${min.notes}"></span></td>
                         <td class="flex gap-2">

--- a/src/main/resources/templates/dialogs/mineralogy.html
+++ b/src/main/resources/templates/dialogs/mineralogy.html
@@ -2,8 +2,16 @@
      id="mineralogyDialog" title="Edit Mineralogy" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="mineralogyId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Minerals Present :</label>
             <input class="kt-input" id="mineralogyMinerals" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Mineral Chemistry :</label>
+            <input class="kt-input" id="mineralogyChemistry" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Volume % :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -327,14 +327,18 @@
         });
 
         init('#mineralogyDialog','#addMineralogy','#saveMineralogy','#mineralogyTable', function(){
-            return [$('#mineralogyMinerals').val(), $('#mineralogyVolume').val(), $('#mineralogyNotes').val()];
+            return [$('#mineralogyId').val(), $('#mineralogyMinerals').val(), $('#mineralogyChemistry').val(), $('#mineralogyVolume').val(), $('#mineralogyNotes').val()];
         }, function(v){
-            $('#mineralogyMinerals').val(v[0].trim());
-            $('#mineralogyVolume').val(v[1].trim());
-            $('#mineralogyNotes').val(v[2].trim());
+            $('#mineralogyId').val(v[0].trim());
+            $('#mineralogyMinerals').val(v[1].trim());
+            $('#mineralogyChemistry').val(v[2].trim());
+            $('#mineralogyVolume').val(v[3].trim());
+            $('#mineralogyNotes').val(v[4].trim());
         }, '/mineralogy/' + materialId + '/' + stage, function(){
             return {
+                id: $('#mineralogyId').val(),
                 mineralsPresent: $('#mineralogyMinerals').val(),
+                mineralChemistry: $('#mineralogyChemistry').val(),
                 volumePercentages: parseFloat($('#mineralogyVolume').val() || 0),
                 notes: $('#mineralogyNotes').val()
             };


### PR DESCRIPTION
## Summary
- show all Mineralogy fields in card and dialog
- support Mineralogy id and chemistry in material form JS

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for io.sci:nnfl:0.0.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a196aec0833398d7093b97951655