### PR TITLE
Include all Element properties in form UI

### DIFF
--- a/src/main/resources/templates/cards/element.html
+++ b/src/main/resources/templates/cards/element.html
@@ -9,18 +9,24 @@
                 <table id="elementTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Name</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Concentration</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Unit</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Uncertainty</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Burnable Poison</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="element : ${material.elemental}">
                     <tr>
+                        <td><span th:text="${element.id}" hidden></span></td>
                         <td><span th:text="${element.element}"></span></td>
                         <td><span th:text="${element.concentration}"></span></td>
+                        <td><span th:text="${element.unit}"></span></td>
                         <td><span th:text="${element.uncertainty}"></span></td>
+                        <td><span th:text="${element.burnablePoison}"></span></td>
                         <td><span th:text="${element.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/element.html
+++ b/src/main/resources/templates/dialogs/element.html
@@ -2,6 +2,10 @@
      id="elementDialog" title="Edit Data" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="elementId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Element Name :</label>
             <input class="kt-input" id="elementName" type="text"/>
         </div>
@@ -10,8 +14,16 @@
             <input class="kt-input" id="elementConcentration" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Element Unit :</label>
+            <input class="kt-input" id="elementUnit" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Element Uncertainty :</label>
             <input class="kt-input" id="elementUncertainty" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Burnable Poison :</label>
+            <input class="kt-input" id="elementBurnablePoison" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Comment(s) :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -119,17 +119,23 @@
         });
 
         init('#elementDialog','#addElement','#saveElement','#elementTable', function(){
-            return [$('#elementName').val(), $('#elementConcentration').val(), $('#elementUncertainty').val(), $('#elementComment').val()];
+            return [$('#elementId').val(), $('#elementName').val(), $('#elementConcentration').val(), $('#elementUnit').val(), $('#elementUncertainty').val(), $('#elementBurnablePoison').val(), $('#elementComment').val()];
         }, function(v){
-            $('#elementName').val(v[0].trim());
-            $('#elementConcentration').val(v[1].trim());
-            $('#elementUncertainty').val(v[2].trim());
-            $('#elementComment').val(v[3].trim());
+            $('#elementId').val(v[0].trim());
+            $('#elementName').val(v[1].trim());
+            $('#elementConcentration').val(v[2].trim());
+            $('#elementUnit').val(v[3].trim());
+            $('#elementUncertainty').val(v[4].trim());
+            $('#elementBurnablePoison').val(v[5].trim());
+            $('#elementComment').val(v[6].trim());
         }, '/element/' + materialId + '/' + stage, function(){
             return {
+                id: $('#elementId').val(),
                 element: $('#elementName').val(),
                 concentration: parseFloat($('#elementConcentration').val() || 0),
+                unit: $('#elementUnit').val(),
                 uncertainty: parseFloat($('#elementUncertainty').val() || 0),
+                burnablePoison: $('#elementBurnablePoison').val(),
                 notes: $('#elementComment').val()
             };
         });


### PR DESCRIPTION
## Summary
- display all element properties in card and dialog
- collect id, unit, and burnable poison in the element dialog script

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a34e36048333b23e15ef8d970e5f