### PR TITLE
Expose all IsotopeRatio fields in UI

### DIFF
--- a/src/main/resources/templates/cards/isotope.html
+++ b/src/main/resources/templates/cards/isotope.html
@@ -9,18 +9,22 @@
                 <table id="isotopeTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Isotope Name</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Ratio</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Uncertainty</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Unit</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="iso : ${material.uraniumIsotopes}">
                     <tr>
+                        <td><span th:text="${iso.id}" hidden></span></td>
                         <td><span th:text="${iso.name}"></span></td>
                         <td><span th:text="${iso.value}"></span></td>
                         <td><span th:text="${iso.uncertainty}"></span></td>
+                        <td><span th:text="${iso.unit}"></span></td>
                         <td><span th:text="${iso.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/isotope.html
+++ b/src/main/resources/templates/dialogs/isotope.html
@@ -2,6 +2,10 @@
      id="isotopeDialog" title="Edit Isotope" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="isotopeId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Isotope Name :</label>
             <input class="kt-input" id="isotopeName" type="text"/>
         </div>
@@ -12,6 +16,10 @@
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Isotope Uncertainty :</label>
             <input class="kt-input" id="isotopeUncertainty" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Unit :</label>
+            <input class="kt-input" id="isotopeUnit" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Comment(s) :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -168,17 +168,21 @@
         });
 
         init('#isotopeDialog','#addIsotope','#saveIsotope','#isotopeTable', function(){
-            return [$('#isotopeName').val(), $('#isotopeRatio').val(), $('#isotopeUncertainty').val(), $('#isotopeComment').val()];
+            return [$('#isotopeId').val(), $('#isotopeName').val(), $('#isotopeRatio').val(), $('#isotopeUncertainty').val(), $('#isotopeUnit').val(), $('#isotopeComment').val()];
         }, function(v){
-            $('#isotopeName').val(v[0].trim());
-            $('#isotopeRatio').val(v[1].trim());
-            $('#isotopeUncertainty').val(v[2].trim());
-            $('#isotopeComment').val(v[3].trim());
+            $('#isotopeId').val(v[0].trim());
+            $('#isotopeName').val(v[1].trim());
+            $('#isotopeRatio').val(v[2].trim());
+            $('#isotopeUncertainty').val(v[3].trim());
+            $('#isotopeUnit').val(v[4].trim());
+            $('#isotopeComment').val(v[5].trim());
         }, '/isotope/' + materialId + '/' + stage, function(){
             return {
+                id: $('#isotopeId').val(),
                 name: $('#isotopeName').val(),
                 value: parseFloat($('#isotopeRatio').val() || 0),
                 uncertainty: parseFloat($('#isotopeUncertainty').val() || 0),
+                unit: $('#isotopeUnit').val(),
                 notes: $('#isotopeComment').val()
             };
         });


### PR DESCRIPTION
## Summary
- Display isotope ID and unit in the Isotope(s) ratio card
- Add ID and unit inputs to the isotope dialog
- Update isotope form initialization to handle ID and unit

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a7d376c883339471f4a948367c82