### PR TITLE
Expand physical characteristics form

### DIFF
--- a/src/main/resources/templates/cards/physical.html
+++ b/src/main/resources/templates/cards/physical.html
@@ -9,18 +9,40 @@
                 <table id="physicalTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">State</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Description</span></span></th>
-                        <th><span class="kt-table-col"><span class="kt-table-col-label">Mass</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Density Value</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Density Unit</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Mechanical Properties</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Dimension</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Cladding Info</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Coating Info</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Assembly Structure</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Surface Oxide Thickness</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Mass Value</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Mass Unit</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="phys : ${material.physicals}">
                     <tr>
+                        <td><div><span th:text="${phys.id}" hidden></span></div></td>
+                        <td><span th:text="${phys.stage}"></span></td>
                         <td><span th:text="${phys.stateOfMatter}"></span></td>
                         <td><span th:text="${phys.description}"></span></td>
-                        <td><span th:text="${phys.mass}"></span></td>
+                        <td><span th:text="${phys.densityValue}"></span></td>
+                        <td><span th:text="${phys.densityUnit}"></span></td>
+                        <td><span th:text="${phys.mechanicalProperties}"></span></td>
+                        <td><span th:text="${phys.dimension}"></span></td>
+                        <td><span th:text="${phys.claddingInfo}"></span></td>
+                        <td><span th:text="${phys.coatingInfo}"></span></td>
+                        <td><span th:text="${phys.assemblyStructure}"></span></td>
+                        <td><span th:text="${phys.surfaceOxideThickness}"></span></td>
+                        <td><span th:text="${phys.massValue}"></span></td>
+                        <td><span th:text="${phys.massUnit}"></span></td>
                         <td><span th:text="${phys.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/physical.html
+++ b/src/main/resources/templates/dialogs/physical.html
@@ -2,6 +2,14 @@
      id="physicalDialog" title="Physical characteristics" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="physicalId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="physicalStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">State :</label>
             <input class="kt-input" id="physicalState" type="text"/>
         </div>
@@ -10,8 +18,44 @@
             <input class="kt-input" id="physicalDescription" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
-            <label class="kt-form-label max-w-56">Mass :</label>
-            <input class="kt-input" id="physicalMass" type="text"/>
+            <label class="kt-form-label max-w-56">Density Value :</label>
+            <input class="kt-input" id="physicalDensityValue" type="number"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Density Unit :</label>
+            <input class="kt-input" id="physicalDensityUnit" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Mechanical Properties :</label>
+            <input class="kt-input" id="physicalMechanical" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Dimension :</label>
+            <input class="kt-input" id="physicalDimension" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Cladding Info :</label>
+            <input class="kt-input" id="physicalCladding" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Coating Info :</label>
+            <input class="kt-input" id="physicalCoating" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Assembly Structure :</label>
+            <input class="kt-input" id="physicalAssembly" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Surface Oxide Thickness :</label>
+            <input class="kt-input" id="physicalOxide" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Mass Value :</label>
+            <input class="kt-input" id="physicalMassValue" type="number"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Mass Unit :</label>
+            <input class="kt-input" id="physicalMassUnit" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Notes :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -499,17 +499,56 @@
         });
 
         init('#physicalDialog','#addPhysical','#savePhysical','#physicalTable', function(){
-            return [$('#physicalState').val(), $('#physicalDescription').val(), $('#physicalMass').val(), $('#physicalNotes').val()];
+            return [
+                $('#physicalId').val(),
+                $('#physicalStage').val(),
+                $('#physicalState').val(),
+                $('#physicalDescription').val(),
+                $('#physicalDensityValue').val(),
+                $('#physicalDensityUnit').val(),
+                $('#physicalMechanical').val(),
+                $('#physicalDimension').val(),
+                $('#physicalCladding').val(),
+                $('#physicalCoating').val(),
+                $('#physicalAssembly').val(),
+                $('#physicalOxide').val(),
+                $('#physicalMassValue').val(),
+                $('#physicalMassUnit').val(),
+                $('#physicalNotes').val()
+            ];
         }, function(v){
-            $('#physicalState').val(v[0].trim());
-            $('#physicalDescription').val(v[1].trim());
-            $('#physicalMass').val(v[2].trim());
-            $('#physicalNotes').val(v[3].trim());
+            $('#physicalId').val(v[0].trim());
+            $('#physicalStage').val(v[1].trim());
+            $('#physicalState').val(v[2].trim());
+            $('#physicalDescription').val(v[3].trim());
+            $('#physicalDensityValue').val(v[4].trim());
+            $('#physicalDensityUnit').val(v[5].trim());
+            $('#physicalMechanical').val(v[6].trim());
+            $('#physicalDimension').val(v[7].trim());
+            $('#physicalCladding').val(v[8].trim());
+            $('#physicalCoating').val(v[9].trim());
+            $('#physicalAssembly').val(v[10].trim());
+            $('#physicalOxide').val(v[11].trim());
+            $('#physicalMassValue').val(v[12].trim());
+            $('#physicalMassUnit').val(v[13].trim());
+            $('#physicalNotes').val(v[14].trim());
         }, '/physical/' + materialId + '/' + stage, function(){
+            var dimension = {};
+            try { dimension = JSON.parse($('#physicalDimension').val() || '{}'); } catch(e) {}
             return {
+                id: $('#physicalId').val(),
+                densityValue: parseFloat($('#physicalDensityValue').val() || 0),
+                densityUnit: $('#physicalDensityUnit').val(),
                 stateOfMatter: $('#physicalState').val(),
+                mechanicalProperties: $('#physicalMechanical').val(),
                 description: $('#physicalDescription').val(),
-                mass: parseFloat($('#physicalMass').val() || 0),
+                dimension: dimension,
+                claddingInfo: $('#physicalCladding').val(),
+                coatingInfo: $('#physicalCoating').val(),
+                assemblyStructure: $('#physicalAssembly').val(),
+                surfaceOxideThickness: $('#physicalOxide').val(),
+                massValue: parseFloat($('#physicalMassValue').val() || 0),
+                massUnit: parseFloat($('#physicalMassUnit').val() || 0),
                 notes: $('#physicalNotes').val()
             };
         });


### PR DESCRIPTION
## Summary
- show all Physical properties on material card
- extend Physical dialog with fields for density, mechanical details, dimensions, cladding, coating, assembly, oxide thickness, and mass
- update material form JS to handle new Physical fields and JSON payload

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM / Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d192205483338e43ed31bf4d4c0a