### PR TITLE
Expand morphology UI to cover all model properties

### DIFF
--- a/src/main/resources/templates/cards/morphology.html
+++ b/src/main/resources/templates/cards/morphology.html
@@ -9,18 +9,32 @@
                 <table id="morphologyTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Lattice Structure</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Aspect Ratio</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Porosity</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Colour</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Particle Size & Distribution</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Shape</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Surface Features</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Plutonium Homogeneity</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="morph : ${material.morphologies}">
                     <tr>
+                        <td><div><span th:text="${morph.id}" hidden></span></div></td>
+                        <td><span th:text="${morph.stage}"></span></td>
                         <td><span th:text="${morph.latticeStructure}"></span></td>
                         <td><span th:text="${morph.aspectRatio}"></span></td>
                         <td><span th:text="${morph.porosity}"></span></td>
+                        <td><span th:text="${morph.colour}"></span></td>
+                        <td><span th:text="${morph.particleSizeAndDistribution}"></span></td>
+                        <td><span th:text="${morph.shape}"></span></td>
+                        <td><span th:text="${morph.surfaceFeatures}"></span></td>
+                        <td><span th:text="${morph.plutoniumHomogeneity}"></span></td>
                         <td><span th:text="${morph.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/morphology.html
+++ b/src/main/resources/templates/dialogs/morphology.html
@@ -2,24 +2,48 @@
      id="morphologyDialog" title="Edit Morphology" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
-            <label class="kt-form-label max-w-56">Crystal Structure :</label>
-            <input class="kt-input" id="morphCrystal" type="text"/>
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="morphId" disabled type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
-            <label class="kt-form-label max-w-56">Lattice A :</label>
-            <input class="kt-input" id="morphA" type="text"/>
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="morphStage" disabled type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
-            <label class="kt-form-label max-w-56">Lattice B :</label>
-            <input class="kt-input" id="morphB" type="text"/>
+            <label class="kt-form-label max-w-56">Lattice Structure :</label>
+            <input class="kt-input" id="morphLatticeStructure" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
-            <label class="kt-form-label max-w-56">Lattice C :</label>
-            <input class="kt-input" id="morphC" type="text"/>
+            <label class="kt-form-label max-w-56">Aspect Ratio :</label>
+            <input class="kt-input" id="morphAspectRatio" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
-            <label class="kt-form-label max-w-56">Comment(s) :</label>
-            <input class="kt-input" id="morphComment" type="text"/>
+            <label class="kt-form-label max-w-56">Porosity :</label>
+            <input class="kt-input" id="morphPorosity" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Colour :</label>
+            <input class="kt-input" id="morphColour" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Particle Size & Distribution :</label>
+            <input class="kt-input" id="morphParticle" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Shape :</label>
+            <input class="kt-input" id="morphShape" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Surface Features :</label>
+            <input class="kt-input" id="morphSurfaceFeatures" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Plutonium Homogeneity :</label>
+            <input class="kt-input" id="morphPlutonium" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Notes :</label>
+            <input class="kt-input" id="morphNotes" type="text"/>
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveMorphology" class="kt-btn kt-btn-primary">Save</button>
@@ -27,3 +51,4 @@
         </div>
     </div>
 </div>
+

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -296,18 +296,43 @@
         });
 
         init('#morphologyDialog','#addMorphology','#saveMorphology','#morphologyTable', function(){
-            return [$('#morphCrystal').val(), $('#morphA').val(), $('#morphB').val(), $('#morphComment').val()];
+            return [
+                $('#morphId').val(),
+                $('#morphStage').val(),
+                $('#morphLatticeStructure').val(),
+                $('#morphAspectRatio').val(),
+                $('#morphPorosity').val(),
+                $('#morphColour').val(),
+                $('#morphParticle').val(),
+                $('#morphShape').val(),
+                $('#morphSurfaceFeatures').val(),
+                $('#morphPlutonium').val(),
+                $('#morphNotes').val()
+            ];
         }, function(v){
-            $('#morphCrystal').val(v[0].trim());
-            $('#morphA').val(v[1].trim());
-            $('#morphB').val(v[2].trim());
-            $('#morphComment').val(v[3].trim());
+            $('#morphId').val(v[0].trim());
+            $('#morphStage').val(v[1].trim());
+            $('#morphLatticeStructure').val(v[2].trim());
+            $('#morphAspectRatio').val(v[3].trim());
+            $('#morphPorosity').val(v[4].trim());
+            $('#morphColour').val(v[5].trim());
+            $('#morphParticle').val(v[6].trim());
+            $('#morphShape').val(v[7].trim());
+            $('#morphSurfaceFeatures').val(v[8].trim());
+            $('#morphPlutonium').val(v[9].trim());
+            $('#morphNotes').val(v[10].trim());
         }, '/morphology/' + materialId + '/' + stage, function(){
             return {
-                latticeStructure: $('#morphCrystal').val(),
-                aspectRatio: parseFloat($('#morphA').val() || 0),
-                porosity: parseFloat($('#morphB').val() || 0),
-                notes: $('#morphComment').val()
+                id: $('#morphId').val(),
+                latticeStructure: $('#morphLatticeStructure').val(),
+                aspectRatio: $('#morphAspectRatio').val(),
+                porosity: $('#morphPorosity').val(),
+                colour: $('#morphColour').val(),
+                particleSizeAndDistribution: $('#morphParticle').val(),
+                shape: $('#morphShape').val(),
+                surfaceFeatures: $('#morphSurfaceFeatures').val(),
+                plutoniumHomogeneity: $('#morphPlutonium').val(),
+                notes: $('#morphNotes').val()
             };
         });
 


### PR DESCRIPTION
## Summary
- Add full morphology properties to card view, including stage, colour, particle details, shape, surface features, plutonium homogeneity and notes
- Extend morphology dialog with corresponding inputs and expose ID and stage fields
- Update material form initialization to read/write the complete morphology object

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d7311f288333a9fa2caff33b35e6