### PR TITLE
Complete Uranium decay card and dialog

### DIFF
--- a/src/main/resources/templates/cards/decay.html
+++ b/src/main/resources/templates/cards/decay.html
@@ -1,24 +1,34 @@
-<div th:fragment="decayCard" class="kt-card kt-card-grid h-full min-w-full">
+<div th:fragment="uraniumDecayCard" class="kt-card kt-card-grid h-full min-w-full">
     <div class="kt-card-header flex justify-between">
         <h3 class="kt-card-title">Uranium decays</h3>
-        <button type="button" id="addDecay" class="kt-btn kt-btn-light">Add</button>
+        <button type="button" id="addUraniumDecay" class="kt-btn kt-btn-light">Add</button>
     </div>
     <div class="kt-card-table">
         <div class="grid" data-kt-datatable="true" data-kt-datatable-page-size="5">
             <div class="kt-scrollable-x-auto">
-                <table id="decayTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
+                <table id="uraniumDecayTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Nuclide</span></span></th>
-                        <th><span class="kt-table-col"><span class="kt-table-col-label">Activity</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Activity (Bq)</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Activity Uncertainty (Bq)</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="decay : ${material.uraniumDecaySeriesRadionuclides}">
                     <tr>
+                        <td>
+                            <div><span th:text="${decay.id}" hidden></span></div>
+                        </td>
+                        <td>
+                            <div><span th:text="${decay.stage}"></span></div>
+                        </td>
                         <td><span th:text="${decay.isotopeName}"></span></td>
                         <td><span th:text="${decay.activityBq}"></span></td>
+                        <td><span th:text="${decay.activityUncertaintyBq}"></span></td>
                         <td><span th:text="${decay.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/decay.html
+++ b/src/main/resources/templates/dialogs/decay.html
@@ -1,21 +1,33 @@
-<div th:fragment="decayDialog"
-     id="decayDialog" title="Edit Uranium Decay" style="display:none;">
+<div th:fragment="uraniumDecayDialog"
+     id="uraniumDecayDialog" title="Edit Uranium Decay" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="uraniumDecayId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="uraniumDecayStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Nuclide :</label>
-            <input class="kt-input" id="decayNuclide" type="text"/>
+            <input class="kt-input" id="uraniumDecayNuclide" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Activity :</label>
-            <input class="kt-input" id="decayActivity" type="text"/>
+            <input class="kt-input" id="uraniumDecayActivity" type="number"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Activity Uncertainty :</label>
+            <input class="kt-input" id="uraniumDecayUncertainty" type="number"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Comment(s) :</label>
-            <input class="kt-input" id="decayComment" type="text"/>
+            <input class="kt-input" id="uraniumDecayComment" type="text"/>
         </div>
         <div class="flex justify-end gap-2">
-            <button type="button" id="saveDecay" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#decayDialog').dialog('close');">Cancel</button>
+            <button type="button" id="saveUraniumDecay" class="kt-btn kt-btn-primary">Save</button>
+            <button type="button" class="kt-btn" onclick="$('#uraniumDecayDialog').dialog('close');">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -35,7 +35,7 @@
         </th:block>
 
         <th:block th:if="${stage == 2}">
-            <div th:replace="~{cards/decay :: decayCard}"></div>
+            <div th:replace="~{cards/decay :: uraniumDecayCard}"></div>
         </th:block>
 
         <th:block th:if="${stage == 1 or stage == 2}">
@@ -68,7 +68,7 @@
 <div th:replace="~{dialogs/trace-element :: traceElementDialog}"></div>
 <div th:replace="~{dialogs/element :: elementDialog}"></div>
 <div th:replace="~{dialogs/morphology :: morphologyDialog}"></div>
-<div th:replace="~{dialogs/decay :: decayDialog}"></div>
+<div th:replace="~{dialogs/decay :: uraniumDecayDialog}"></div>
 <div th:replace="~{dialogs/container :: containerDialog}"></div>
 <div th:replace="~{dialogs/general-info :: generalInfoDialog}"></div>
 <div th:replace="~{dialogs/geology :: geologyDialog}"></div>
@@ -336,17 +336,29 @@
             };
         });
 
-        init('#decayDialog','#addDecay','#saveDecay','#decayTable', function(){
-            return [$('#decayNuclide').val(), $('#decayActivity').val(), $('#decayComment').val()];
+        init('#uraniumDecayDialog','#addUraniumDecay','#saveUraniumDecay','#uraniumDecayTable', function(){
+            return [
+                $('#uraniumDecayId').val(),
+                $('#uraniumDecayStage').val(),
+                $('#uraniumDecayNuclide').val(),
+                $('#uraniumDecayActivity').val(),
+                $('#uraniumDecayUncertainty').val(),
+                $('#uraniumDecayComment').val()
+            ];
         }, function(v){
-            $('#decayNuclide').val(v[0].trim());
-            $('#decayActivity').val(v[1].trim());
-            $('#decayComment').val(v[2].trim());
+            $('#uraniumDecayId').val(v[0].trim());
+            $('#uraniumDecayStage').val(v[1].trim());
+            $('#uraniumDecayNuclide').val(v[2].trim());
+            $('#uraniumDecayActivity').val(v[3].trim());
+            $('#uraniumDecayUncertainty').val(v[4].trim());
+            $('#uraniumDecayComment').val(v[5].trim());
         }, '/decay/' + materialId + '/' + stage, function(){
             return {
-                isotopeName: $('#decayNuclide').val(),
-                activityBq: parseFloat($('#decayActivity').val() || 0),
-                notes: $('#decayComment').val()
+                id: $('#uraniumDecayId').val(),
+                isotopeName: $('#uraniumDecayNuclide').val(),
+                activityBq: parseFloat($('#uraniumDecayActivity').val() || 0),
+                activityUncertaintyBq: parseFloat($('#uraniumDecayUncertainty').val() || 0),
+                notes: $('#uraniumDecayComment').val()
             };
         });
 


### PR DESCRIPTION
## Summary
- Show all UraniumDecaySeriesRadionuclide fields in card and dialog
- Add full init logic for Uranium decay modal in material-form

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d9c60fe8833381704636c892bb52