### PR TITLE
Ensure ProcessInfo UI covers all model fields

### DIFF
--- a/src/main/resources/templates/cards/process-info.html
+++ b/src/main/resources/templates/cards/process-info.html
@@ -9,6 +9,8 @@
                 <table id="processInfoTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Process Type</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Location</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Start Date</span></span></th>
@@ -19,6 +21,8 @@
                     </thead>
                     <tbody th:each="proc : ${material.processInformation}">
                     <tr>
+                        <td><div><span th:text="${proc.id}" hidden></span></div></td>
+                        <td><span th:text="${proc.stage}"></span></td>
                         <td><span th:text="${proc.processTypeOrDescription}"></span></td>
                         <td><span th:text="${proc.locationOfProcessingSite}"></span></td>
                         <td><span th:text="${proc.startDate}"></span></td>

--- a/src/main/resources/templates/dialogs/process-info.html
+++ b/src/main/resources/templates/dialogs/process-info.html
@@ -2,6 +2,14 @@
      id="processInfoDialog" title="Edit Process Information" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="processId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="processStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Process Type :</label>
             <input class="kt-input" id="processType" type="text"/>
         </div>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -579,15 +579,27 @@
         });
 
         init('#processInfoDialog','#addProcessInfo','#saveProcessInfo','#processInfoTable', function(){
-            return [$('#processType').val(), $('#processLocation').val(), $('#processStart').val(), $('#processEnd').val(), $('#processNotes').val()];
+            return [
+                $('#processId').val(),
+                $('#processStage').val(),
+                $('#processType').val(),
+                $('#processLocation').val(),
+                $('#processStart').val(),
+                $('#processEnd').val(),
+                $('#processNotes').val()
+            ];
         }, function(v){
-            $('#processType').val(v[0].trim());
-            $('#processLocation').val(v[1].trim());
-            $('#processStart').val(v[2].trim());
-            $('#processEnd').val(v[3].trim());
-            $('#processNotes').val(v[4].trim());
+            $('#processId').val(v[0].trim());
+            $('#processStage').val(v[1].trim());
+            $('#processType').val(v[2].trim());
+            $('#processLocation').val(v[3].trim());
+            $('#processStart').val(v[4].trim());
+            $('#processEnd').val(v[5].trim());
+            $('#processNotes').val(v[6].trim());
         }, '/process-info/' + materialId + '/' + stage, function(){
             return {
+                id: $('#processId').val(),
+                stage: $('#processStage').val(),
                 processTypeOrDescription: $('#processType').val(),
                 locationOfProcessingSite: $('#processLocation').val(),
                 startDate: $('#processStart').val(),


### PR DESCRIPTION
## Summary
- show ProcessInfo ID and stage in card and dialog
- include ID, stage and other properties when editing ProcessInfo entries

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dadd462c8333ae2684e3802c6f58