### PR TITLE
Expand source activity info fields

### DIFF
--- a/src/main/resources/templates/cards/source-activity-info.html
+++ b/src/main/resources/templates/cards/source-activity-info.html
@@ -9,6 +9,8 @@
                 <table id="sourceActivityInfoTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Activity (Bq)</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Reference Date</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Neutron Intensity</span></span></th>
@@ -18,6 +20,8 @@
                     </thead>
                     <tbody th:each="sai : ${material.sourceActivityInfo}">
                     <tr>
+                        <td><span th:text="${sai.id}" hidden></span></td>
+                        <td><span th:text="${sai.stage}"></span></td>
                         <td><span th:text="${sai.activityBq}"></span></td>
                         <td><span th:text="${sai.referenceDate}"></span></td>
                         <td><span th:text="${sai.neutronIntensityPerSec}"></span></td>

--- a/src/main/resources/templates/dialogs/source-activity-info.html
+++ b/src/main/resources/templates/dialogs/source-activity-info.html
@@ -2,6 +2,14 @@
      id="sourceActivityInfoDialog" title="Edit Source Activity Info" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="sourceActivityId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="sourceActivityStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Activity (Bq) :</label>
             <input class="kt-input" id="sourceActivityValue" type="text"/>
         </div>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -684,17 +684,27 @@
         });
 
         init('#sourceActivityInfoDialog','#addSourceActivityInfo','#saveSourceActivityInfo','#sourceActivityInfoTable', function(){
-            return [$('#sourceActivityValue').val(), $('#sourceActivityDate').val(), $('#sourceActivityNeutron').val(), $('#sourceActivityNotes').val()];
+            return [
+                $('#sourceActivityId').val(),
+                $('#sourceActivityStage').val(),
+                $('#sourceActivityValue').val(),
+                $('#sourceActivityDate').val(),
+                $('#sourceActivityNeutron').val(),
+                $('#sourceActivityNotes').val()
+            ];
         }, function(v){
-            $('#sourceActivityValue').val(v[0].trim());
-            $('#sourceActivityDate').val(v[1].trim());
-            $('#sourceActivityNeutron').val(v[2].trim());
-            $('#sourceActivityNotes').val(v[3].trim());
+            $('#sourceActivityId').val(v[0].trim());
+            $('#sourceActivityStage').val(v[1].trim());
+            $('#sourceActivityValue').val(v[2].trim());
+            $('#sourceActivityDate').val(v[3].trim());
+            $('#sourceActivityNeutron').val(v[4].trim());
+            $('#sourceActivityNotes').val(v[5].trim());
         }, '/source-activity-info/' + materialId + '/' + stage, function(){
             return {
+                id: $('#sourceActivityId').val(),
                 activityBq: parseFloat($('#sourceActivityValue').val() || 0),
                 referenceDate: $('#sourceActivityDate').val(),
-                neutronIntensityPerSec: $('#sourceActivityNeutron').val(),
+                neutronIntensityPerSec: parseFloat($('#sourceActivityNeutron').val() || 0),
                 notes: $('#sourceActivityNotes').val()
             };
         });


### PR DESCRIPTION
## Summary
- Show ID and stage in Source Activity Info card and dialog
- Update dialog initialization to handle all SourceActivityInfo properties

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for io.sci:nnfl:0.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ede60f3483338f7e7d8459d397fa