### PR TITLE
Handle all SerialNumber fields in UI

### DIFF
--- a/src/main/resources/templates/cards/serial-number.html
+++ b/src/main/resources/templates/cards/serial-number.html
@@ -9,6 +9,8 @@
                 <table id="serialNumberTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Serial Number</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
@@ -16,6 +18,8 @@
                     </thead>
                     <tbody th:each="sn : ${material.serialNumbers}">
                     <tr>
+                        <td><div><span th:text="${sn.id}" hidden></span></div></td>
+                        <td><span th:text="${sn.stage}"></span></td>
                         <td><span th:text="${sn.serialNumber}"></span></td>
                         <td><span th:text="${sn.notes}"></span></td>
                         <td class="flex gap-2">

--- a/src/main/resources/templates/dialogs/serial-number.html
+++ b/src/main/resources/templates/dialogs/serial-number.html
@@ -2,6 +2,14 @@
      id="serialNumberDialog" title="Edit Serial Number" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="serialNumberId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="serialNumberStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Serial Number :</label>
             <input class="kt-input" id="serialNumberValue" type="text"/>
         </div>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -672,16 +672,27 @@
         });
 
         init('#serialNumberDialog','#addSerialNumber','#saveSerialNumber','#serialNumberTable', function(){
-            return [$('#serialNumberValue').val(), $('#serialNumberNotes').val()];
+            return [
+                $('#serialNumberId').val(),
+                $('#serialNumberStage').val() || stage,
+                $('#serialNumberValue').val(),
+                $('#serialNumberNotes').val()
+            ];
         }, function(v){
-            $('#serialNumberValue').val(v[0].trim());
-            $('#serialNumberNotes').val(v[1].trim());
+            $('#serialNumberId').val(v[0].trim());
+            $('#serialNumberStage').val(v[1].trim());
+            $('#serialNumberValue').val(v[2].trim());
+            $('#serialNumberNotes').val(v[3].trim());
         }, '/serial-number/' + materialId + '/' + stage, function(){
             return {
+                id: $('#serialNumberId').val(),
+                stage: $('#serialNumberStage').val() || stage,
                 serialNumber: $('#serialNumberValue').val(),
                 notes: $('#serialNumberNotes').val()
             };
         });
+
+        $('#addSerialNumber').click(function(){ $('#serialNumberStage').val(stage); });
 
         init('#sourceActivityInfoDialog','#addSourceActivityInfo','#saveSourceActivityInfo','#sourceActivityInfoTable', function(){
             return [$('#sourceActivityValue').val(), $('#sourceActivityDate').val(), $('#sourceActivityNeutron').val(), $('#sourceActivityNotes').val()];


### PR DESCRIPTION
## Summary
- Show ID and Stage on Serial Number card
- Add ID and Stage inputs to Serial Number dialog
- Include id and stage when saving serial numbers via `init` routine

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ee17bf548333ae44d343f70a8e06