### PR TITLE
feat: extend irradiation form

### DIFF
--- a/src/main/resources/templates/cards/irradiation.html
+++ b/src/main/resources/templates/cards/irradiation.html
@@ -9,20 +9,30 @@
                 <table id="irradiationTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Reactor Type</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Burn Up</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Assembly Power History</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Operating Records Ref</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Load Date</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Discharge Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Radiation Level</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="irr : ${material.irradiationHistories}">
                     <tr>
+                        <td><span th:text="${irr.id}" hidden></span></td>
+                        <td><span th:text="${irr.stage}"></span></td>
                         <td><span th:text="${irr.reactorType}"></span></td>
                         <td><span th:text="${irr.burnUp}"></span></td>
+                        <td><span th:text="${irr.assemblyPowerHistory}"></span></td>
+                        <td><span th:text="${irr.operatingRecordsRef}"></span></td>
                         <td><span th:text="${irr.loadDate}"></span></td>
                         <td><span th:text="${irr.dischargeDate}"></span></td>
+                        <td><span th:text="${irr.radiationLevel}"></span></td>
                         <td><span th:text="${irr.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/irradiation.html
+++ b/src/main/resources/templates/dialogs/irradiation.html
@@ -2,6 +2,14 @@
      id="irradiationDialog" title="Edit Irradiation History" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="irradiationId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="irradiationStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Reactor Type :</label>
             <input class="kt-input" id="irradiationReactor" type="text"/>
         </div>
@@ -10,12 +18,24 @@
             <input class="kt-input" id="irradiationBurnUp" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Assembly Power History :</label>
+            <input class="kt-input" id="irradiationAssemblyPowerHistory" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Operating Records Ref :</label>
+            <input class="kt-input" id="irradiationOperatingRecordsRef" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Load Date :</label>
             <input class="kt-input" id="irradiationLoadDate" type="date"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Discharge Date :</label>
             <input class="kt-input" id="irradiationDischargeDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Radiation Level :</label>
+            <input class="kt-input" id="irradiationRadiationLevel" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Notes :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -529,19 +529,38 @@
         });
 
         init('#irradiationDialog','#addIrradiation','#saveIrradiation','#irradiationTable', function(){
-            return [$('#irradiationReactor').val(), $('#irradiationBurnUp').val(), $('#irradiationLoadDate').val(), $('#irradiationDischargeDate').val(), $('#irradiationNotes').val()];
+            return [
+                $('#irradiationId').val(),
+                $('#irradiationStage').val(),
+                $('#irradiationReactor').val(),
+                $('#irradiationBurnUp').val(),
+                $('#irradiationAssemblyPowerHistory').val(),
+                $('#irradiationOperatingRecordsRef').val(),
+                $('#irradiationLoadDate').val(),
+                $('#irradiationDischargeDate').val(),
+                $('#irradiationRadiationLevel').val(),
+                $('#irradiationNotes').val()];
         }, function(v){
-            $('#irradiationReactor').val(v[0].trim());
-            $('#irradiationBurnUp').val(v[1].trim());
-            $('#irradiationLoadDate').val(v[2].trim());
-            $('#irradiationDischargeDate').val(v[3].trim());
-            $('#irradiationNotes').val(v[4].trim());
+            $('#irradiationId').val(v[0].trim());
+            $('#irradiationStage').val(v[1].trim());
+            $('#irradiationReactor').val(v[2].trim());
+            $('#irradiationBurnUp').val(v[3].trim());
+            $('#irradiationAssemblyPowerHistory').val(v[4].trim());
+            $('#irradiationOperatingRecordsRef').val(v[5].trim());
+            $('#irradiationLoadDate').val(v[6].trim());
+            $('#irradiationDischargeDate').val(v[7].trim());
+            $('#irradiationRadiationLevel').val(v[8].trim());
+            $('#irradiationNotes').val(v[9].trim());
         }, '/irradiation/' + materialId + '/' + stage, function(){
             return {
+                id: $('#irradiationId').val(),
                 reactorType: $('#irradiationReactor').val(),
                 burnUp: $('#irradiationBurnUp').val(),
+                assemblyPowerHistory: $('#irradiationAssemblyPowerHistory').val(),
+                operatingRecordsRef: $('#irradiationOperatingRecordsRef').val(),
                 loadDate: $('#irradiationLoadDate').val(),
                 dischargeDate: $('#irradiationDischargeDate').val(),
+                radiationLevel: $('#irradiationRadiationLevel').val(),
                 notes: $('#irradiationNotes').val()
             };
         });


### PR DESCRIPTION
## Summary
- display all IrradiationHistory fields in irradiation card
- extend irradiation dialog with IDs, stage and additional history fields
- update irradiation form logic to handle new properties

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ef1abef48333924bc19d354c8872