### PR TITLE
Expand isotope activity dialog and card

### DIFF
--- a/src/main/resources/templates/cards/isotope-activity.html
+++ b/src/main/resources/templates/cards/isotope-activity.html
@@ -9,18 +9,26 @@
                 <table id="isotopeActivityTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Isotope</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Activity (Bq)</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Activity Uncertainty (Bq)</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Reference Date</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Major</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="act : ${material.isotopeActivities}">
                     <tr>
+                        <td><span th:text="${act.id}" hidden></span></td>
+                        <td><span th:text="${act.stage}"></span></td>
                         <td><span th:text="${act.isotopeName}"></span></td>
                         <td><span th:text="${act.activityBq}"></span></td>
+                        <td><span th:text="${act.activityUncertaintyBq}"></span></td>
                         <td><span th:text="${act.referenceDate}"></span></td>
+                        <td><span th:text="${act.major}"></span></td>
                         <td><span th:text="${act.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/isotope-activity.html
+++ b/src/main/resources/templates/dialogs/isotope-activity.html
@@ -2,6 +2,14 @@
      id="isotopeActivityDialog" title="Edit Isotope Activity" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="isotopeActivityId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="isotopeActivityStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Isotope :</label>
             <input class="kt-input" id="isotopeActivityName" type="text"/>
         </div>
@@ -10,8 +18,16 @@
             <input class="kt-input" id="isotopeActivityValue" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Activity Uncertainty (Bq) :</label>
+            <input class="kt-input" id="isotopeActivityUncertainty" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Reference Date :</label>
             <input class="kt-input" id="isotopeActivityDate" type="date"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Major :</label>
+            <input class="kt-input" id="isotopeActivityMajor" type="checkbox"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Notes :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -547,17 +547,33 @@
         });
 
         init('#isotopeActivityDialog','#addIsotopeActivity','#saveIsotopeActivity','#isotopeActivityTable', function(){
-            return [$('#isotopeActivityName').val(), $('#isotopeActivityValue').val(), $('#isotopeActivityDate').val(), $('#isotopeActivityNotes').val()];
+            return [
+                $('#isotopeActivityId').val(),
+                $('#isotopeActivityStage').val(),
+                $('#isotopeActivityName').val(),
+                $('#isotopeActivityValue').val(),
+                $('#isotopeActivityUncertainty').val(),
+                $('#isotopeActivityDate').val(),
+                $('#isotopeActivityMajor').is(':checked'),
+                $('#isotopeActivityNotes').val()
+            ];
         }, function(v){
-            $('#isotopeActivityName').val(v[0].trim());
-            $('#isotopeActivityValue').val(v[1].trim());
-            $('#isotopeActivityDate').val(v[2].trim());
-            $('#isotopeActivityNotes').val(v[3].trim());
+            $('#isotopeActivityId').val(v[0].trim());
+            $('#isotopeActivityStage').val(v[1].trim());
+            $('#isotopeActivityName').val(v[2].trim());
+            $('#isotopeActivityValue').val(v[3].trim());
+            $('#isotopeActivityUncertainty').val(v[4].trim());
+            $('#isotopeActivityDate').val(v[5].trim());
+            $('#isotopeActivityMajor').prop('checked', v[6].trim().toLowerCase() === 'true');
+            $('#isotopeActivityNotes').val(v[7].trim());
         }, '/isotope-activity/' + materialId + '/' + stage, function(){
             return {
+                id: $('#isotopeActivityId').val(),
                 isotopeName: $('#isotopeActivityName').val(),
                 activityBq: parseFloat($('#isotopeActivityValue').val() || 0),
+                activityUncertaintyBq: parseFloat($('#isotopeActivityUncertainty').val() || 0),
                 referenceDate: $('#isotopeActivityDate').val(),
+                major: $('#isotopeActivityMajor').is(':checked'),
                 notes: $('#isotopeActivityNotes').val()
             };
         });


### PR DESCRIPTION
## Summary
- Display all `IsotopeActivity` fields in the isotope activity table card
- Extend isotope activity dialog to edit id, stage, uncertainty, major flag and notes
- Update page script to handle the new fields when creating or editing entries

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ef6527688333a6a7ce765586ab48