### PR TITLE
Expose full container attributes in form

### DIFF
--- a/src/main/resources/templates/cards/container.html
+++ b/src/main/resources/templates/cards/container.html
@@ -9,18 +9,24 @@
                 <table id="containerTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Type</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Volume</span></span></th>
-                        <th><span class="kt-table-col"><span class="kt-table-col-label">Serial Number</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Unit</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Dimensions</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="container : ${material.containers}">
                     <tr>
+                        <td><span th:text="${container.id}" hidden></span></td>
+                        <td><span th:text="${container.stage}"></span></td>
                         <td><span th:text="${container.type}"></span></td>
-                        <td><span th:text="${container.volume}"></span></td>
-                        <td><span th:text="${container.serialNumber}"></span></td>
+                        <td><span th:text="${container.volumeValue}"></span></td>
+                        <td><span th:text="${container.volumeUnit}"></span></td>
+                        <td><span th:text="${container.dimensions}"></span></td>
                         <td><span th:text="${container.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/container.html
+++ b/src/main/resources/templates/dialogs/container.html
@@ -2,16 +2,28 @@
      id="containerDialog" title="Edit Container" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="containerId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="containerStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Type :</label>
             <input class="kt-input" id="containerType" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Volume :</label>
-            <input class="kt-input" id="containerVolume" type="text"/>
+            <input class="kt-input" id="containerVolume" type="number"/>
         </div>
         <div class="flex items-baseline gap-2.5">
-            <label class="kt-form-label max-w-56">Serial Number :</label>
-            <input class="kt-input" id="containerSerial" type="text"/>
+            <label class="kt-form-label max-w-56">Unit :</label>
+            <input class="kt-input" id="containerUnit" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Dimensions :</label>
+            <input class="kt-input" id="containerDimensions" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Notes :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -415,20 +415,35 @@
         });
 
         init('#containerDialog','#addContainer','#saveContainer','#containerTable', function(){
-            return [$('#containerType').val(), $('#containerVolume').val(), $('#containerSerial').val(), $('#containerNotes').val()];
+            return [
+                $('#containerId').val(),
+                $('#containerStage').val(),
+                $('#containerType').val(),
+                $('#containerVolume').val(),
+                $('#containerUnit').val(),
+                $('#containerDimensions').val(),
+                $('#containerNotes').val()
+            ];
         }, function(v){
-            $('#containerType').val(v[0].trim());
-            $('#containerVolume').val(v[1].trim());
-            $('#containerSerial').val(v[2].trim());
-            $('#containerNotes').val(v[3].trim());
+            $('#containerId').val(v[0].trim());
+            $('#containerStage').val(v[1].trim());
+            $('#containerType').val(v[2].trim());
+            $('#containerVolume').val(v[3].trim());
+            $('#containerUnit').val(v[4].trim());
+            $('#containerDimensions').val(v[5].trim());
+            $('#containerNotes').val(v[6].trim());
         }, '/container/' + materialId + '/' + stage, function(){
             return {
+                id: $('#containerId').val(),
                 type: $('#containerType').val(),
-                volume: parseFloat($('#containerVolume').val() || 0),
-                serialNumber: $('#containerSerial').val(),
+                volumeValue: parseFloat($('#containerVolume').val() || 0),
+                volumeUnit: $('#containerUnit').val(),
+                dimensions: $('#containerDimensions').val(),
                 notes: $('#containerNotes').val()
             };
         });
+
+        $('#addContainer').click(function(){ $('#containerStage').val(stage); });
 
         init('#generalInfoDialog','#addGeneralInfo','#saveGeneralInfo','#generalInfoTable', function(){
             return [


### PR DESCRIPTION
## Summary
- Display container id, stage, volume unit, and dimensions in container card
- Extend container dialog and initialization logic to handle all Container model properties

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f160e92083338fb119bbcfe197e7