### PR TITLE
Expand source description UI

### DIFF
--- a/src/main/resources/templates/cards/source-description.html
+++ b/src/main/resources/templates/cards/source-description.html
@@ -9,18 +9,34 @@
                 <table id="sourceDescriptionTable" class="kt-table kt-table-border table-fixed" data-kt-datatable-table="true">
                     <thead>
                     <tr>
+                        <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Source Type</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Quantity</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Description</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Dimensions</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Encapsulation/Cladding</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Serial Number</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Shipping History</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Receiving History</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Radiograph/Photograph</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
                     <tbody th:each="sd : ${material.sourceDescriptions}">
                     <tr>
+                        <td><div><span th:text="${sd.id}" hidden></span></div></td>
+                        <td><span th:text="${sd.stage}"></span></td>
                         <td><span th:text="${sd.sourceType}"></span></td>
                         <td><span th:text="${sd.quantity}"></span></td>
+                        <td><span th:text="${sd.description}"></span></td>
+                        <td><span th:text="${sd.dimensions}"></span></td>
+                        <td><span th:text="${sd.encapsulationOrCladding}"></span></td>
                         <td><span th:text="${sd.serialNumber}"></span></td>
+                        <td><span th:text="${sd.shippingHistory}"></span></td>
+                        <td><span th:text="${sd.receivingHistory}"></span></td>
+                        <td><span th:text="${sd.radiographOrPhotograph}"></span></td>
                         <td><span th:text="${sd.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/source-description.html
+++ b/src/main/resources/templates/dialogs/source-description.html
@@ -2,6 +2,14 @@
      id="sourceDescriptionDialog" title="Edit Source Description" style="display:none;">
     <div class="grid gap-5">
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">ID :</label>
+            <input class="kt-input" id="sourceDescriptionId" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Stage :</label>
+            <input class="kt-input" id="sourceDescriptionStage" disabled type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Source Type :</label>
             <input class="kt-input" id="sourceDescriptionType" type="text"/>
         </div>
@@ -10,8 +18,32 @@
             <input class="kt-input" id="sourceDescriptionQuantity" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Description :</label>
+            <input class="kt-input" id="sourceDescriptionDescription" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Dimensions :</label>
+            <input class="kt-input" id="sourceDescriptionDimensions" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Encapsulation/Cladding :</label>
+            <input class="kt-input" id="sourceDescriptionEncapsulation" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Serial Number :</label>
             <input class="kt-input" id="sourceDescriptionSerial" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Shipping History :</label>
+            <input class="kt-input" id="sourceDescriptionShipping" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Receiving History :</label>
+            <input class="kt-input" id="sourceDescriptionReceiving" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Radiograph/Photograph :</label>
+            <input class="kt-input" id="sourceDescriptionRadiograph" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Notes :</label>
@@ -23,3 +55,4 @@
         </div>
     </div>
 </div>
+

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -756,17 +756,45 @@
         });
 
         init('#sourceDescriptionDialog','#addSourceDescription','#saveSourceDescription','#sourceDescriptionTable', function(){
-            return [$('#sourceDescriptionType').val(), $('#sourceDescriptionQuantity').val(), $('#sourceDescriptionSerial').val(), $('#sourceDescriptionNotes').val()];
+            return [
+                $('#sourceDescriptionId').val(),
+                $('#sourceDescriptionStage').val(),
+                $('#sourceDescriptionType').val(),
+                $('#sourceDescriptionQuantity').val(),
+                $('#sourceDescriptionDescription').val(),
+                $('#sourceDescriptionDimensions').val(),
+                $('#sourceDescriptionEncapsulation').val(),
+                $('#sourceDescriptionSerial').val(),
+                $('#sourceDescriptionShipping').val(),
+                $('#sourceDescriptionReceiving').val(),
+                $('#sourceDescriptionRadiograph').val(),
+                $('#sourceDescriptionNotes').val()
+            ];
         }, function(v){
-            $('#sourceDescriptionType').val(v[0].trim());
-            $('#sourceDescriptionQuantity').val(v[1].trim());
-            $('#sourceDescriptionSerial').val(v[2].trim());
-            $('#sourceDescriptionNotes').val(v[3].trim());
+            $('#sourceDescriptionId').val(v[0].trim());
+            $('#sourceDescriptionStage').val(v[1].trim());
+            $('#sourceDescriptionType').val(v[2].trim());
+            $('#sourceDescriptionQuantity').val(v[3].trim());
+            $('#sourceDescriptionDescription').val(v[4].trim());
+            $('#sourceDescriptionDimensions').val(v[5].trim());
+            $('#sourceDescriptionEncapsulation').val(v[6].trim());
+            $('#sourceDescriptionSerial').val(v[7].trim());
+            $('#sourceDescriptionShipping').val(v[8].trim());
+            $('#sourceDescriptionReceiving').val(v[9].trim());
+            $('#sourceDescriptionRadiograph').val(v[10].trim());
+            $('#sourceDescriptionNotes').val(v[11].trim());
         }, '/source-description/' + materialId + '/' + stage, function(){
             return {
+                id: $('#sourceDescriptionId').val(),
                 sourceType: $('#sourceDescriptionType').val(),
                 quantity: $('#sourceDescriptionQuantity').val(),
+                description: $('#sourceDescriptionDescription').val(),
+                dimensions: $('#sourceDescriptionDimensions').val(),
+                encapsulationOrCladding: $('#sourceDescriptionEncapsulation').val(),
                 serialNumber: $('#sourceDescriptionSerial').val(),
+                shippingHistory: $('#sourceDescriptionShipping').val(),
+                receivingHistory: $('#sourceDescriptionReceiving').val(),
+                radiographOrPhotograph: $('#sourceDescriptionRadiograph').val(),
                 notes: $('#sourceDescriptionNotes').val()
             };
         });


### PR DESCRIPTION
## Summary
- Show full SourceDescription details in card
- Add inputs for all SourceDescription fields
- Wire dialog fields to JSON payload

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f18d8e7c8333a4aa053769f7840e