### PR TITLE
feat: extend physical material properties

### DIFF
--- a/src/main/resources/templates/cards/physical.html
+++ b/src/main/resources/templates/cards/physical.html
@@ -16,13 +16,14 @@
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Density Value</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Density Unit</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Mechanical Info</span></span></th>
-                        <th><span class="kt-table-col"><span class="kt-table-col-label">Dimension</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Dimensions</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Cladding Info</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Coating Info</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Assembly Structure</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Surface Oxide</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Mass Value</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Mass Unit</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Serial Numbers</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
@@ -36,13 +37,14 @@
                         <td><span th:text="${phys.densityValue}"></span></td>
                         <td><span th:text="${phys.densityUnit}"></span></td>
                         <td><span th:text="${phys.mechanicalProperties}"></span></td>
-                        <td><span th:text="${phys.dimension}"></span></td>
+                        <td><span th:text="${phys.dimensions}"></span></td>
                         <td><span th:text="${phys.claddingInfo}"></span></td>
                         <td><span th:text="${phys.coatingInfo}"></span></td>
                         <td><span th:text="${phys.assemblyStructure}"></span></td>
                         <td><span th:text="${phys.surfaceOxideThickness}"></span></td>
                         <td><span th:text="${phys.massValue}"></span></td>
                         <td><span th:text="${phys.massUnit}"></span></td>
+                        <td><span th:text="${phys.serialNumbers}"></span></td>
                         <td><span th:text="${phys.notes}"></span></td>
                         <td class="flex gap-2">
                             <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/physical.html
+++ b/src/main/resources/templates/dialogs/physical.html
@@ -30,8 +30,8 @@
             <input class="kt-input" id="physicalMechanical" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
-            <label class="kt-form-label max-w-56">Dimension :</label>
-            <input class="kt-input" id="physicalDimension" type="text"/>
+            <label class="kt-form-label max-w-56">Dimensions :</label>
+            <input class="kt-input" id="physicalDimensions" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Cladding Info :</label>
@@ -56,6 +56,10 @@
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Mass Unit :</label>
             <input class="kt-input" id="physicalMassUnit" type="text"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Serial Numbers :</label>
+            <input class="kt-input" id="physicalSerialNumbers" type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Notes :</label>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -631,13 +631,14 @@
                 $('#physicalDensityValue').val(),
                 $('#physicalDensityUnit').val(),
                 $('#physicalMechanical').val(),
-                $('#physicalDimension').val(),
+                $('#physicalDimensions').val(),
                 $('#physicalCladding').val(),
                 $('#physicalCoating').val(),
                 $('#physicalAssembly').val(),
                 $('#physicalOxide').val(),
                 $('#physicalMassValue').val(),
                 $('#physicalMassUnit').val(),
+                $('#physicalSerialNumbers').val(),
                 $('#physicalNotes').val()
             ];
         }, function(v){
@@ -648,17 +649,16 @@
             $('#physicalDensityValue').val(v[4].trim());
             $('#physicalDensityUnit').val(v[5].trim());
             $('#physicalMechanical').val(v[6].trim());
-            $('#physicalDimension').val(v[7].trim());
+            $('#physicalDimensions').val(v[7].trim());
             $('#physicalCladding').val(v[8].trim());
             $('#physicalCoating').val(v[9].trim());
             $('#physicalAssembly').val(v[10].trim());
             $('#physicalOxide').val(v[11].trim());
             $('#physicalMassValue').val(v[12].trim());
             $('#physicalMassUnit').val(v[13].trim());
-            $('#physicalNotes').val(v[14].trim());
+            $('#physicalSerialNumbers').val(v[14].trim());
+            $('#physicalNotes').val(v[15].trim());
         }, '/physical/' + materialId + '/' + stage, function(){
-            var dimension = {};
-            //try { dimension = JSON.parse($('#physicalDimension').val() || '{}'); } catch(e) {}
             return {
                 id: $('#physicalId').val(),
                 densityValue: parseFloat($('#physicalDensityValue').val() || 0),
@@ -666,13 +666,14 @@
                 stateOfMatter: $('#physicalState').val(),
                 mechanicalProperties: $('#physicalMechanical').val(),
                 description: $('#physicalDescription').val(),
-                dimension: $('#physicalDimension').val(),
+                dimensions: $('#physicalDimensions').val(),
                 claddingInfo: $('#physicalCladding').val(),
                 coatingInfo: $('#physicalCoating').val(),
                 assemblyStructure: $('#physicalAssembly').val(),
                 surfaceOxideThickness: $('#physicalOxide').val(),
                 massValue: parseFloat($('#physicalMassValue').val() || 0),
                 massUnit: $('#physicalMassUnit').val(),
+                serialNumbers: $('#physicalSerialNumbers').val(),
                 notes: $('#physicalNotes').val()
             };
         });


### PR DESCRIPTION
## Summary
- show full Physical model in card table
- expand dialog with dimensions and serial number inputs
- handle new fields in material form initialization

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f1d4ff54833386ed067bc6ea8d3e