### PR TITLE
Refactor material dialogs to Bootstrap modals

### DIFF
--- a/src/main/resources/templates/dialogs/chemical-form.html
+++ b/src/main/resources/templates/dialogs/chemical-form.html
@@ -23,7 +23,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveChemical" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#chemicalDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/container.html
+++ b/src/main/resources/templates/dialogs/container.html
@@ -31,7 +31,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveContainer" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#containerDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/decay.html
+++ b/src/main/resources/templates/dialogs/decay.html
@@ -27,7 +27,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveUraniumDecay" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#uraniumDecayDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/element.html
+++ b/src/main/resources/templates/dialogs/element.html
@@ -31,7 +31,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveElement" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#elementDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/general-info.html
+++ b/src/main/resources/templates/dialogs/general-info.html
@@ -79,7 +79,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveGeneralInfo" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#generalInfoDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/geology.html
+++ b/src/main/resources/templates/dialogs/geology.html
@@ -35,7 +35,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveGeology" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#geologyDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/irradiation.html
+++ b/src/main/resources/templates/dialogs/irradiation.html
@@ -43,7 +43,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveIrradiation" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#irradiationDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/isotope-activity.html
+++ b/src/main/resources/templates/dialogs/isotope-activity.html
@@ -35,7 +35,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveIsotopeActivity" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#isotopeActivityDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/mineralogy.html
+++ b/src/main/resources/templates/dialogs/mineralogy.html
@@ -27,7 +27,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveMineralogy" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#mineralogyDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/morphology.html
+++ b/src/main/resources/templates/dialogs/morphology.html
@@ -47,7 +47,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveMorphology" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#morphologyDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/physical.html
+++ b/src/main/resources/templates/dialogs/physical.html
@@ -67,7 +67,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="savePhysical" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#physicalDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/plutonium-isotope.html
+++ b/src/main/resources/templates/dialogs/plutonium-isotope.html
@@ -31,7 +31,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="savePlutoniumIsotope" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#plutoniumIsotopeDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/process-info.html
+++ b/src/main/resources/templates/dialogs/process-info.html
@@ -31,7 +31,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveProcessInfo" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#processInfoDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/serial-number.html
+++ b/src/main/resources/templates/dialogs/serial-number.html
@@ -19,7 +19,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveSerialNumber" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#serialNumberDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/source-activity-info.html
+++ b/src/main/resources/templates/dialogs/source-activity-info.html
@@ -27,7 +27,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveSourceActivityInfo" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#sourceActivityInfoDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/source-description.html
+++ b/src/main/resources/templates/dialogs/source-description.html
@@ -51,7 +51,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveSourceDescription" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#sourceDescriptionDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/stable-isotope.html
+++ b/src/main/resources/templates/dialogs/stable-isotope.html
@@ -31,7 +31,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveStableIsotope" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#stableIsotopeDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/uranium-isotope.html
+++ b/src/main/resources/templates/dialogs/uranium-isotope.html
@@ -31,7 +31,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveUraniumIsotope" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#uraniumIsotopeDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/dialogs/uranium.html
+++ b/src/main/resources/templates/dialogs/uranium.html
@@ -35,7 +35,7 @@
         </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveUranium" class="kt-btn kt-btn-primary">Save</button>
-            <button type="button" class="kt-btn" onclick="$('#uraniumDialog').dialog('close');">Cancel</button>
+            <button type="button" class="kt-btn" data-bs-dismiss="modal">Cancel</button>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -106,9 +106,7 @@
 <div th:replace="~{dialogs/source-description :: sourceDescriptionDialog}"></div>
 
 
-<link rel="stylesheet" th:href="@{https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css}" />
 <script th:src="@{https://code.jquery.com/jquery-3.7.1.min.js}"></script>
-<script th:src="@{https://code.jquery.com/ui/1.13.2/jquery-ui.js}"></script>
 <script>
     $(function(){
         var materialId = window.location.pathname.split('/')[3];
@@ -116,15 +114,40 @@
         var csrfToken = document.querySelector('meta[name="_csrf"]')?.getAttribute('content');
         var csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.getAttribute('content');
 
+        function convertToModal(dialogId) {
+            var el = document.querySelector(dialogId);
+            if (!el) { return null; }
+            var title = el.getAttribute('title') || '';
+            var body = el.innerHTML;
+            var modal = document.createElement('div');
+            modal.className = 'modal fade';
+            modal.id = el.id;
+            modal.setAttribute('tabindex', '-1');
+            modal.setAttribute('aria-hidden', 'true');
+            modal.innerHTML =
+                '<div class="modal-dialog modal-dialog-centered mw-650px"><div class="modal-content"><div class="modal-header"><h2 class="modal-title">' +
+                title +
+                '</h2><div class="btn btn-sm btn-icon btn-active-light-primary" data-bs-dismiss="modal"><i class="ki-outline ki-cross fs-2"></i></div></div><div class="modal-body">' +
+                body +
+                '</div></div></div>';
+            el.replaceWith(modal);
+            return modal;
+        }
+
         function init(dialogId, addBtnId, saveBtnId, tableId, getData, setData, endpoint, getJsonData){
             var currentRow = null;
-            $(dialogId).dialog({ autoOpen:false, modal:true, width:640 });
-            $(addBtnId).click(function(){ currentRow=null; $(dialogId).dialog('open'); });
+            var modalElement = convertToModal(dialogId);
+            if (!modalElement) { return; }
+            var modal = new bootstrap.Modal(modalElement);
+            $(addBtnId).click(function(){ currentRow=null; modal.show(); });
             $(tableId).on('click','.editRow', function(){
                 currentRow = $(this).closest('tr');
                 var values = currentRow.children('td').slice(0,-1).map(function(){ return $(this).text(); }).get();
                 setData(values);
-                $(dialogId).dialog('open');
+                modal.show();
+            });
+            $(modalElement).on('hidden.bs.modal', function(){
+                $(dialogId + ' input').val('');
             });
             $(saveBtnId).click(function(){
                 var data = getData();
@@ -151,8 +174,7 @@
                         console.error(err);
                         alert('Save failed: ' + err.message);
                     });
-                $(dialogId).dialog('close');
-                $(dialogId + ' input').val('');
+                modal.hide();
             });
         }
 


### PR DESCRIPTION
## Summary
- Remove jQuery UI assets and initialize dialogs as Bootstrap modals
- Switch dialog cancel buttons to `data-bs-dismiss="modal"`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fc7951b88333afb32572050c6d83