### PR TITLE
Add OpenAI-backed MaterialRecord search helper

### DIFF
--- a/src/main/java/io/sci/nnfl/config/OpenAiConfig.java
+++ b/src/main/java/io/sci/nnfl/config/OpenAiConfig.java
@@ -1,0 +1,27 @@
+package io.sci.nnfl.config;
+
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * Spring configuration that wires the OpenAI client used by the natural language search helper.
+ */
+@Configuration
+@EnableConfigurationProperties(OpenAiProperties.class)
+public class OpenAiConfig {
+
+    @Bean
+    @ConditionalOnExpression("T(org.springframework.util.StringUtils).hasText('${openai.api-key:}')")
+    public OpenAIClient openAiClient(OpenAiProperties properties) {
+        OpenAIOkHttpClient.Builder builder = OpenAIOkHttpClient.builder().fromEnv();
+        if (StringUtils.hasText(properties.getApiKey())) {
+            builder.apiKey(properties.getApiKey());
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/io/sci/nnfl/config/OpenAiProperties.java
+++ b/src/main/java/io/sci/nnfl/config/OpenAiProperties.java
@@ -1,0 +1,59 @@
+package io.sci.nnfl.config;
+
+import com.openai.models.ChatModel;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration properties for the OpenAI integration used by natural language search.
+ */
+@ConfigurationProperties(prefix = "openai")
+public class OpenAiProperties {
+
+    /**
+     * API key used to authenticate requests against the OpenAI API.
+     */
+    private String apiKey;
+
+    /**
+     * Model identifier to use for translating natural language prompts into MQL.
+     */
+    private String model = ChatModel.GPT_4_1_MINI.asString();
+
+    /**
+     * Soft limit for the amount of tokens returned by the model when generating MQL.
+     */
+    private int maxOutputTokens = 512;
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        if (StringUtils.hasText(model)) {
+            this.model = model;
+        }
+    }
+
+    public int getMaxOutputTokens() {
+        return maxOutputTokens;
+    }
+
+    public void setMaxOutputTokens(int maxOutputTokens) {
+        if (maxOutputTokens > 0) {
+            this.maxOutputTokens = maxOutputTokens;
+        }
+    }
+
+    public boolean hasApiKey() {
+        return StringUtils.hasText(apiKey);
+    }
+}

--- a/src/main/java/io/sci/nnfl/service/MaterialRecordMqlConverter.java
+++ b/src/main/java/io/sci/nnfl/service/MaterialRecordMqlConverter.java
@@ -1,0 +1,200 @@
+package io.sci.nnfl.service;
+
+import com.openai.client.OpenAIClient;
+import com.openai.models.ResponseFormatJsonObject;
+import com.openai.models.responses.Response;
+import com.openai.models.responses.ResponseCreateParams;
+import com.openai.models.responses.ResponseOutputItem;
+import com.openai.models.responses.ResponseOutputMessage;
+import com.openai.models.responses.ResponseOutputText;
+import com.openai.models.responses.ResponseTextConfig;
+import io.sci.nnfl.config.OpenAiProperties;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Utility component that relies on OpenAI to translate natural language prompts into
+ * MongoDB query objects targeting {@code MaterialRecord} documents.
+ */
+@Component
+public class MaterialRecordMqlConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MaterialRecordMqlConverter.class);
+    private static final Pattern CODE_FENCE_PATTERN = Pattern.compile("```(?:json)?\\s*(.*?)```", Pattern.DOTALL);
+
+    private static final String MATERIAL_RECORD_GUIDE = """
+You are an assistant that translates natural-language search requirements into MongoDB query filter documents
+for the `materials` collection that stores `MaterialRecord` documents.
+Each MaterialRecord document contains these relevant top-level fields:
+- state (string)
+- generalInfo[] sub-documents with keys such as dataRecordDate, countryOfOrigin, producer, supplier, analyticalLab, batchId and notes
+- geology[] sub-documents describing depositType, hostRock, country, region, latitude and longitude
+- mineralogy[], uranium[], uraniumIsotopes[], stableIsotopes[] and traceElements[] which contain measurement objects with name, value, unit and stage information
+- chemicalForms[], physicals[], morphologies[], uraniumDecaySeriesRadionuclides[], processInformation[], elemental[], containers[], serialNumbers[], plutoniumIsotopes[], irradiationHistories[], isotopeActivities[], sourceDescriptions[] and sourceActivityInfo[] which are arrays of contextual sub-documents that also include a stage field
+- creationDateTime (date) showing when the record was created
+When a field is an array of sub-documents use `$elemMatch` to constrain nested properties.
+Apply case-insensitive matching for free-form text by using a `$regex` with `$options: "i"`.
+Dates must use extended JSON, for example `{ "$gte": { "$date": "2020-01-01T00:00:00Z" } }`.
+Combine independent requirements with `$and` or `$or` arrays. Use comparison operators such as `$gte` and `$lte` when the request mentions ranges.
+If the request cannot be represented with the available fields respond with an empty filter `{}`.
+Example (do not repeat this in your response):
+Request: samples from Canada created after 2015 with uranium 235 ratio above 0.7
+Filter:
+{
+  "$and": [
+    { "generalInfo": { "$elemMatch": { "countryOfOrigin": { "$regex": "^Canada$", "$options": "i" } } } },
+    { "creationDateTime": { "$gte": { "$date": "2015-01-01T00:00:00Z" } } },
+    { "uraniumIsotopes": { "$elemMatch": { "name": { "$regex": "235", "$options": "i" }, "value": { "$gt": 0.7 } } } }
+  ]
+}
+""";
+
+    private static final String PROMPT_TEMPLATE = """
+%s
+
+Produce a single MongoDB filter expressed as Extended JSON for MaterialRecord documents in the `materials` collection.
+Respond with only the JSON object and no additional commentary or code fences.
+User request:
+%s
+""";
+
+    private final OpenAIClient openAiClient;
+    private final OpenAiProperties properties;
+    private final ResponseTextConfig jsonResponseConfig;
+
+    public MaterialRecordMqlConverter(@Nullable OpenAIClient openAiClient, OpenAiProperties properties) {
+        this.openAiClient = openAiClient;
+        this.properties = properties;
+        this.jsonResponseConfig = ResponseTextConfig.builder()
+                .format(ResponseFormatJsonObject.builder().build())
+                .build();
+    }
+
+    /**
+     * Indicates whether the converter can reach the OpenAI service.
+     */
+    public boolean isConfigured() {
+        return openAiClient != null && properties.hasApiKey();
+    }
+
+    /**
+     * Converts a natural language query into a MongoDB {@link Query} if possible.
+     */
+    public Optional<Query> toQuery(String naturalLanguageQuery) {
+        return toJsonFilter(naturalLanguageQuery)
+                .flatMap(this::parseDocument)
+                .map(BasicQuery::new);
+    }
+
+    /**
+     * Converts a natural language query into a JSON representation of an MQL filter.
+     */
+    public Optional<String> toJsonFilter(String naturalLanguageQuery) {
+        if (!StringUtils.hasText(naturalLanguageQuery)) {
+            return Optional.empty();
+        }
+        if (!isConfigured()) {
+            LOGGER.warn("Skipping natural language search because the OpenAI client is not configured.");
+            return Optional.empty();
+        }
+
+        String prompt = buildPrompt(naturalLanguageQuery.trim());
+
+        try {
+            ResponseCreateParams.Builder paramsBuilder = ResponseCreateParams.builder()
+                    .model(properties.getModel())
+                    .input(prompt)
+                    .temperature(0d)
+                    .text(jsonResponseConfig);
+
+            int maxTokens = properties.getMaxOutputTokens();
+            if (maxTokens > 0) {
+                paramsBuilder.maxOutputTokens((long) maxTokens);
+            }
+
+            Response response = openAiClient.responses().create(paramsBuilder.build());
+            return extractJson(response);
+        } catch (Exception ex) {
+            LOGGER.warn("Failed to translate natural language query into a MongoDB filter", ex);
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> extractJson(Response response) {
+        if (response == null) {
+            return Optional.empty();
+        }
+
+        List<ResponseOutputItem> outputItems = response.output();
+        if (outputItems == null || outputItems.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String raw = outputItems.stream()
+                .map(ResponseOutputItem::message)
+                .flatMap(Optional::stream)
+                .map(ResponseOutputMessage::content)
+                .flatMap(List::stream)
+                .map(ResponseOutputMessage.Content::outputText)
+                .flatMap(Optional::stream)
+                .map(ResponseOutputText::text)
+                .collect(Collectors.joining("\n"))
+                .trim();
+
+        if (!StringUtils.hasText(raw)) {
+            return Optional.empty();
+        }
+
+        String sanitized = sanitize(raw);
+        return StringUtils.hasText(sanitized) ? Optional.of(sanitized) : Optional.empty();
+    }
+
+    private Optional<Document> parseDocument(String json) {
+        try {
+            return Optional.of(Document.parse(json));
+        } catch (RuntimeException parseError) {
+            LOGGER.warn("Generated JSON filter could not be parsed: {}", json, parseError);
+            return Optional.empty();
+        }
+    }
+
+    private String sanitize(String raw) {
+        String candidate = raw.trim();
+
+        Matcher codeFence = CODE_FENCE_PATTERN.matcher(candidate);
+        if (codeFence.find()) {
+            candidate = codeFence.group(1).trim();
+        }
+
+        candidate = candidate.replaceFirst("(?i)^(mongodb\\s+filter|filter|query)\\s*:\\s*", "");
+
+        int start = candidate.indexOf('{');
+        int end = candidate.lastIndexOf('}');
+        if (start >= 0 && end > start) {
+            candidate = candidate.substring(start, end + 1);
+        }
+
+        candidate = candidate.trim();
+        if (candidate.endsWith(";")) {
+            candidate = candidate.substring(0, candidate.length() - 1).trim();
+        }
+        return candidate;
+    }
+
+    private String buildPrompt(String query) {
+        return String.format(Locale.ROOT, PROMPT_TEMPLATE, MATERIAL_RECORD_GUIDE, query);
+    }
+}

--- a/src/main/java/io/sci/nnfl/web/SearchController.java
+++ b/src/main/java/io/sci/nnfl/web/SearchController.java
@@ -1,23 +1,51 @@
 package io.sci.nnfl.web;
 
+import io.sci.nnfl.model.MaterialRecord;
+import io.sci.nnfl.service.MaterialRecordService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Collections;
+import java.util.List;
 
 @Controller
 public class SearchController {
 
+    private final MaterialRecordService materialRecordService;
+
+    public SearchController(MaterialRecordService materialRecordService) {
+        this.materialRecordService = materialRecordService;
+    }
+
     @GetMapping("/search")
-    public String showSearch(@RequestParam(value = "q", required = false) String query, Model model) {
+    public String showSearch(@RequestParam(value = "q", required = false) String query,
+                             @RequestParam(value = "version", required = false) String version,
+                             Model model) {
         String sanitizedQuery = query != null ? query.trim() : "";
-        boolean hasQuery = !sanitizedQuery.isEmpty();
+        String selectedVersion = StringUtils.hasText(version) ? version : "1";
+        boolean naturalLanguageRequested = "2".equals(selectedVersion);
+        boolean hasQuery = StringUtils.hasText(sanitizedQuery);
+        boolean searchEnabled = materialRecordService.isNaturalLanguageSearchEnabled();
+
+        boolean searchAttempted = hasQuery && (!naturalLanguageRequested || searchEnabled);
+        List<MaterialRecord> results = Collections.emptyList();
+
+        if (searchAttempted) {
+            results = naturalLanguageRequested
+                    ? materialRecordService.searchByNaturalLanguage(sanitizedQuery)
+                    : materialRecordService.search(sanitizedQuery);
+        }
 
         model.addAttribute("query", sanitizedQuery);
         model.addAttribute("hasQuery", hasQuery);
-        model.addAttribute("results", Collections.emptyList());
+        model.addAttribute("results", results);
+        model.addAttribute("searchEnabled", searchEnabled);
+        model.addAttribute("searchAttempted", searchAttempted);
+        model.addAttribute("usingNaturalLanguage", naturalLanguageRequested);
+        model.addAttribute("version", selectedVersion);
 
         return "search";
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,8 @@ spring:
   web:
     resources:
       static-locations: classpath:/static/
+openai:
+  api-key: ${OPENAI_API_KEY:}
+  model: ${OPENAI_MODEL:gpt-4.1-mini}
+  max-output-tokens: ${OPENAI_MAX_OUTPUT_TOKENS:512}
+

--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -18,6 +18,18 @@
                            class="kt-input grow"
                            placeholder="Enter a prompt to search"
                            th:value="${query}"/>
+                    <label class="sr-only" for="searchVersion">Search version</label>
+                    <select id="searchVersion"
+                            name="version"
+                            class="kt-input lg:w-44"
+                            aria-label="Search version">
+                        <option value="1" th:selected="${version == '1'}">Version 1 (MQL)</option>
+                        <option value="2"
+                                th:selected="${version == '2'}"
+                                th:disabled="${!searchEnabled}">
+                            Version 2 (Natural language)
+                        </option>
+                    </select>
                     <button class="kt-btn kt-btn-primary lg:w-auto" type="submit">
                         Search
                     </button>
@@ -29,11 +41,14 @@
                         </p>
                     </div>
                     <div th:if="${hasQuery}" class="grid gap-3">
-                        <p class="text-sm text-muted-foreground" th:if="${#lists.isEmpty(results)}">
+                        <p class="text-sm text-muted-foreground" th:if="${usingNaturalLanguage and !searchEnabled}">
+                            Natural language search is currently unavailable because the OpenAI client is not configured.
+                        </p>
+                        <p class="text-sm text-muted-foreground" th:if="${searchAttempted and #lists.isEmpty(results)}">
                             No results found for
                             <span class="font-medium" th:text="${query}">your query</span>.
                         </p>
-                        <ul th:if="${!#lists.isEmpty(results)}" class="grid gap-3">
+                        <ul th:if="${searchAttempted and !#lists.isEmpty(results)}" class="grid gap-3">
                             <li class="kt-card kt-card-bordered p-4" th:each="result : ${results}">
                                 <span class="text-sm" th:text="${result}">Search result</span>
                             </li>


### PR DESCRIPTION
## Summary
- configure the OpenAI client and properties for natural language query support
- add a MaterialRecordMqlConverter that uses OpenAI to turn prompts into MongoDB queries and expose it through MaterialRecordService
- hook the search controller/view to the converter and surface configuration status, plus define OpenAI settings in application.yml
- add a search mode selector so users can choose between manual MQL filters and natural language prompts

## Testing
- mvn -q -DskipTests compile *(fails: Non-resolvable parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d78ba1a0833395cf67901e8c58a5