### PR TITLE
Switch search form to POST and add loading indicator

### DIFF
--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -9,8 +9,10 @@
                 <h3 class="kt-card-title">Search</h3>
             </div>
             <div class="kt-card-content grid gap-5">
-                <form class="flex flex-col lg:flex-row gap-3 lg:gap-4 items-stretch"
-                      th:action="@{/search}" method="get">
+                <form id="searchForm"
+                      class="flex flex-col lg:flex-row gap-3 lg:gap-4 items-stretch"
+                      th:action="@{/search}" method="post">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <label class="sr-only" for="searchQuery">Search prompt</label>
                     <input id="searchQuery"
                            type="text"
@@ -21,15 +23,20 @@
                     <label class="sr-only" for="searchVersion">Search version</label>
                     <select id="searchVersion"
                             name="v"
-                            class="kt-input lg:w-auto"
+                            class="kt-input w-full lg:w-40"
                             aria-label="Search version">
-                        <option value="1" th:selected="${version == '1'}">Natural language v1</option>
-                        <option value="2" th:selected="${version == '2'}">Natural language v2</option>
-                        <option value="3" th:selected="${version == '3'}">MQL</option>                    </select>
-                    <button class="kt-btn kt-btn-primary lg:w-auto" type="submit">
+                        <option value="1" th:selected="${version == '1'}">NL v1</option>
+                        <option value="2" th:selected="${version == '2'}">NL v2</option>
+                        <option value="3" th:selected="${version == '3'}">MQL</option>
+                    </select>
+                    <button id="searchSubmit" class="kt-btn kt-btn-primary lg:w-auto" type="submit">
                         Search
                     </button>
                 </form>
+                <div id="searchLoading" class="hidden items-center gap-2 text-sm text-muted-foreground" role="status" aria-live="polite">
+                    <span class="h-4 w-4 rounded-full border-2 border-muted-foreground border-t-transparent animate-spin"></span>
+                    <span>Searching…</span>
+                </div>
                 <div id="searchResults" class="grid gap-4">
                     <div th:if="${!hasQuery}">
                         <p class="text-sm text-muted-foreground">
@@ -59,5 +66,24 @@
         </div>
     </div>
 </div>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const form = document.getElementById('searchForm');
+        const spinner = document.getElementById('searchLoading');
+        const submitButton = document.getElementById('searchSubmit');
+
+        if (!form || !spinner) {
+            return;
+        }
+
+        form.addEventListener('submit', function () {
+            spinner.classList.remove('hidden');
+            spinner.classList.add('flex');
+            if (submitButton) {
+                submitButton.setAttribute('disabled', 'disabled');
+            }
+        });
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the search form to submit via POST, include CSRF support, shorten the version selector text, and add a loading spinner during submissions
- adjust the SearchController to serve the empty form over GET and process search requests via POST while guarding against missing parameters

## Testing
- `mvn test` *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c91477b25c83338893141694c55dca