### PR TITLE
Configure WAR packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <groupId>io.sci</groupId>
     <artifactId>nnfl</artifactId>
     <version>0.0.1</version>
+    <packaging>war</packaging>
     <name>nnfl</name>
     <description>National Nuclear Forensics Libraries</description>
 
@@ -47,6 +48,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -147,6 +153,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- configure the project to build a WAR by setting packaging to `war`
- add a provided-scope Tomcat starter for deployment to an external servlet container
- include the Maven WAR plugin to prepare the archive

## Testing
- `mvn -DskipTests package` *(fails: unable to reach repo.maven.apache.org due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ca06344ec88333812174327bc7bebc