### PR TITLE
Prompt for material ID on creation

### DIFF
--- a/src/main/resources/templates/materials.html
+++ b/src/main/resources/templates/materials.html
@@ -5,11 +5,12 @@
     <div class="kt-card">
         <div class="kt-card-header flex justify-between">
             <h3 class="kt-card-title">Material Records</h3>
-            <form th:action="@{|/materials|}" method="post"
-                  onsubmit="return confirm('Create new record?');">
+            <form id="createMaterialForm" th:action="@{|/materials|}" method="post">
                 <input type="hidden" th:if="${_csrf != null}"
                        th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-                <button type="submit" class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-additem"></i></button>
+                <input type="hidden" name="id" id="newMaterialId" />
+                <button type="button" id="openCreateMaterialDialog"
+                        class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost"><i class="ki-filled ki-additem"></i></button>
             </form>
         </div>
         <div class="kt-card-content">
@@ -52,6 +53,19 @@
                 </table>
             </div>
         </div>
+        <div id="materialIdDialog" title="Create Material Record" style="display:none;">
+            <div class="grid gap-3 text-xs">
+                <label class="grid gap-1">
+                    <span class="font-semibold">Material ID</span>
+                    <input type="text" id="materialIdInput" class="kt-input" placeholder="Enter material ID" />
+                </label>
+                <div id="materialIdError" class="text-xs" style="display:none;color:#dc2626;">Please enter a material ID.</div>
+                <div class="flex justify-end gap-2">
+                    <button type="button" id="materialIdSubmitBtn" class="kt-btn kt-btn-primary">Create</button>
+                    <button type="button" id="materialIdCancelBtn" class="kt-btn">Cancel</button>
+                </div>
+            </div>
+        </div>
         <div id="stageDialog" title="Select Stage" style="display:none;">
             <div class="grid gap-5 text-xs">
                 <select id="stageSelect" class="kt-input">
@@ -73,6 +87,58 @@
                     scrollX: true,
                     autoWidth: false,
                     columnDefs: [ { targets: '_all', className: 'whitespace-nowrap' } ]
+                });
+
+                var createMaterialForm = $('#createMaterialForm');
+                var newMaterialIdField = $('#newMaterialId');
+                var materialIdInput = $('#materialIdInput');
+                var materialIdError = $('#materialIdError');
+                var materialIdDialog = $('#materialIdDialog').dialog({
+                    autoOpen: false,
+                    modal: true,
+                    width: 400,
+                    open: function(){
+                        materialIdInput.val('');
+                        newMaterialIdField.val('');
+                        materialIdError.hide();
+                        setTimeout(function(){ materialIdInput.trigger('focus'); }, 0);
+                    }
+                });
+
+                createMaterialForm.on('submit', function(e){
+                    if(!$.trim(newMaterialIdField.val())){
+                        e.preventDefault();
+                        materialIdDialog.dialog('open');
+                    }
+                });
+
+                $('#openCreateMaterialDialog').on('click', function(e){
+                    e.preventDefault();
+                    materialIdDialog.dialog('open');
+                });
+
+                $('#materialIdCancelBtn').on('click', function(){
+                    materialIdDialog.dialog('close');
+                });
+
+                $('#materialIdSubmitBtn').on('click', function(){
+                    var enteredId = $.trim(materialIdInput.val());
+                    if(!enteredId){
+                        materialIdError.show();
+                        materialIdInput.trigger('focus');
+                        return;
+                    }
+                    materialIdError.hide();
+                    newMaterialIdField.val(enteredId);
+                    materialIdDialog.dialog('close');
+                    createMaterialForm.trigger('submit');
+                });
+
+                materialIdInput.on('keypress', function(e){
+                    if(e.which === 13){
+                        e.preventDefault();
+                        $('#materialIdSubmitBtn').click();
+                    }
                 });
 
                 var stageDialog = $('#stageDialog').dialog({ autoOpen: false, modal: true, width: 400 });


### PR DESCRIPTION
## Summary
- add a dialog to let users enter a material ID before creating a record
- wire the creation form to require the manual ID and submit it with the request

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca1a6a08b4833394852c3bc28aeb34