### PR TITLE
Add support for attachments in morphology, general info, and source description

### DIFF
--- a/src/main/resources/templates/cards/general-info.html
+++ b/src/main/resources/templates/cards/general-info.html
@@ -29,6 +29,7 @@
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Acquisition</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Used Archived</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Image/PDF</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
@@ -54,6 +55,13 @@
                         <td><span th:text="${#dates.format(info.informationAcquisitionDate, 'yyyy-MM-dd')}"></span></td>
                         <td><span th:text="${info.usedArchivedInformation}"></span></td>
                         <td><span th:text="${info.notes}"></span></td>
+                        <td>
+                            <span hidden th:text="${info.imageFile}"></span>
+                            <a th:if="${info.imageFile}" th:href="${info.imageFile}" target="_blank" rel="noopener noreferrer"
+                               class="kt-link" aria-label="View attachment">
+                                <i class="ki-filled ki-eye"></i>
+                            </a>
+                        </td>
                         <td class="flex gap-2">
                             <th:block th:if="${info.stage == T(io.sci.nnfl.model.Stage).values()[stage]}">
                                 <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/cards/morphology.html
+++ b/src/main/resources/templates/cards/morphology.html
@@ -20,6 +20,7 @@
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Surface Features</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Plutonium Homogeneity</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Image/PDF</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
@@ -36,6 +37,13 @@
                         <td><span th:text="${morph.surfaceFeatures}"></span></td>
                         <td><span th:text="${morph.plutoniumHomogeneity}"></span></td>
                         <td><span th:text="${morph.notes}"></span></td>
+                        <td>
+                            <span hidden th:text="${morph.imageFile}"></span>
+                            <a th:if="${morph.imageFile}" th:href="${morph.imageFile}" target="_blank" rel="noopener noreferrer"
+                               class="kt-link" aria-label="View attachment">
+                                <i class="ki-filled ki-eye"></i>
+                            </a>
+                        </td>
                         <td class="flex gap-2">
                             <th:block th:if="${morph.stage == T(io.sci.nnfl.model.Stage).values()[stage]}">
                                 <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/cards/source-description.html
+++ b/src/main/resources/templates/cards/source-description.html
@@ -21,6 +21,7 @@
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Receiving History</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Radiograph/Photograph</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Notes</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Image/PDF</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Action</span></span></th>
                     </tr>
                     </thead>
@@ -38,6 +39,13 @@
                         <td><span th:text="${sd.receivingHistory}"></span></td>
                         <td><span th:text="${sd.radiographOrPhotograph}"></span></td>
                         <td><span th:text="${sd.notes}"></span></td>
+                        <td>
+                            <span hidden th:text="${sd.imageFile}"></span>
+                            <a th:if="${sd.imageFile}" th:href="${sd.imageFile}" target="_blank" rel="noopener noreferrer"
+                               class="kt-link" aria-label="View attachment">
+                                <i class="ki-filled ki-eye"></i>
+                            </a>
+                        </td>
                         <td class="flex gap-2">
                             <th:block th:if="${sd.stage == T(io.sci.nnfl.model.Stage).values()[stage]}">
                                 <button class="kt-btn kt-btn-sm kt-btn-icon kt-btn-ghost editRow">

--- a/src/main/resources/templates/dialogs/general-info.html
+++ b/src/main/resources/templates/dialogs/general-info.html
@@ -81,6 +81,20 @@
             <label class="kt-form-label max-w-56">Notes :</label>
             <input class="kt-input" id="generalNotes" type="text"/>
         </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Image/PDF :</label>
+            <div class="flex flex-col gap-1 w-full">
+                <input class="kt-input" id="generalImageFileInput" type="file" accept="image/*,application/pdf"/>
+                <input id="generalImageFile" type="hidden"/>
+                <div class="flex items-center gap-2 text-xs">
+                    <a id="generalImageFilePreview" class="kt-link" href="#" target="_blank" rel="noopener noreferrer"
+                       style="display:none;">View current file</a>
+                    <button type="button" id="generalImageFileClear" class="kt-btn kt-btn-sm kt-btn-light"
+                            style="display:none;">Remove file</button>
+                </div>
+                <span class="text-xs text-gray-500">Supported formats: images or PDF.</span>
+            </div>
+        </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveGeneralInfo" class="kt-btn kt-btn-primary">Save</button>
         </div>

--- a/src/main/resources/templates/dialogs/morphology.html
+++ b/src/main/resources/templates/dialogs/morphology.html
@@ -45,6 +45,20 @@
             <label class="kt-form-label max-w-56">Notes :</label>
             <input class="kt-input" id="morphNotes" type="text"/>
         </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Image/PDF :</label>
+            <div class="flex flex-col gap-1 w-full">
+                <input class="kt-input" id="morphImageFileInput" type="file" accept="image/*,application/pdf"/>
+                <input id="morphImageFile" type="hidden"/>
+                <div class="flex items-center gap-2 text-xs">
+                    <a id="morphImageFilePreview" class="kt-link" href="#" target="_blank" rel="noopener noreferrer"
+                       style="display:none;">View current file</a>
+                    <button type="button" id="morphImageFileClear" class="kt-btn kt-btn-sm kt-btn-light"
+                            style="display:none;">Remove file</button>
+                </div>
+                <span class="text-xs text-gray-500">Supported formats: images or PDF.</span>
+            </div>
+        </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveMorphology" class="kt-btn kt-btn-primary">Save</button>
         </div>

--- a/src/main/resources/templates/dialogs/source-description.html
+++ b/src/main/resources/templates/dialogs/source-description.html
@@ -49,6 +49,20 @@
             <label class="kt-form-label max-w-56">Notes :</label>
             <input class="kt-input" id="sourceDescriptionNotes" type="text"/>
         </div>
+        <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Image/PDF :</label>
+            <div class="flex flex-col gap-1 w-full">
+                <input class="kt-input" id="sourceDescriptionImageFileInput" type="file" accept="image/*,application/pdf"/>
+                <input id="sourceDescriptionImageFile" type="hidden"/>
+                <div class="flex items-center gap-2 text-xs">
+                    <a id="sourceDescriptionImageFilePreview" class="kt-link" href="#" target="_blank"
+                       rel="noopener noreferrer" style="display:none;">View current file</a>
+                    <button type="button" id="sourceDescriptionImageFileClear" class="kt-btn kt-btn-sm kt-btn-light"
+                            style="display:none;">Remove file</button>
+                </div>
+                <span class="text-xs text-gray-500">Supported formats: images or PDF.</span>
+            </div>
+        </div>
         <div class="flex justify-end gap-2">
             <button type="button" id="saveSourceDescription" class="kt-btn kt-btn-primary">Save</button>
         </div>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -156,6 +156,63 @@
             });
         }
 
+        function createFileField(fileInputSelector, hiddenInputSelector, previewSelector, clearSelector) {
+            var $fileInput = $(fileInputSelector);
+            var $hiddenInput = $(hiddenInputSelector);
+            var $previewLink = $(previewSelector);
+            var $clearButton = clearSelector ? $(clearSelector) : null;
+            var defaultText = $previewLink.text() || 'View file';
+
+            function updateControls(fileName) {
+                var value = $hiddenInput.val();
+                if (value) {
+                    $previewLink.attr('href', value)
+                        .text(fileName || defaultText)
+                        .show();
+                    if ($clearButton) {
+                        $clearButton.show();
+                    }
+                } else {
+                    $previewLink.removeAttr('href')
+                        .text(defaultText)
+                        .hide();
+                    if ($clearButton) {
+                        $clearButton.hide();
+                    }
+                }
+            }
+
+            $previewLink.hide();
+
+            if ($clearButton) {
+                $clearButton.hide().on('click', function(){
+                    $hiddenInput.val('');
+                    $fileInput.val('');
+                    updateControls();
+                });
+            }
+
+            $fileInput.on('change', function(){
+                var file = this.files && this.files[0];
+                if (!file) {
+                    return;
+                }
+                var reader = new FileReader();
+                reader.onload = function(event){
+                    $hiddenInput.val(event.target.result);
+                    updateControls(file.name);
+                };
+                reader.readAsDataURL(file);
+            });
+
+            updateControls();
+
+            return {
+                refresh: updateControls,
+                clearInput: function(){ $fileInput.val(''); }
+            };
+        }
+
         init('#chemicalDialog','#addChemical','#saveChemical','#chemicalTable', function(){
             return [
                 $('#chemicalId').val(),
@@ -363,6 +420,18 @@
             };
         });
 
+        var morphologyFileField = createFileField('#morphImageFileInput', '#morphImageFile', '#morphImageFilePreview', '#morphImageFileClear');
+        $('#morphologyDialog').on('dialogopen', function(){
+            if (!$('#morphId').val()) {
+                $('#morphImageFile').val('');
+            }
+            morphologyFileField.clearInput();
+            morphologyFileField.refresh();
+        }).on('dialogclose', function(){
+            morphologyFileField.clearInput();
+            morphologyFileField.refresh();
+        });
+
         init('#morphologyDialog','#addMorphology','#saveMorphology','#morphologyTable', function(){
             return [
                 $('#morphId').val(),
@@ -375,7 +444,8 @@
                 $('#morphShape').val(),
                 $('#morphSurfaceFeatures').val(),
                 $('#morphPlutonium').val(),
-                $('#morphNotes').val()
+                $('#morphNotes').val(),
+                $('#morphImageFile').val()
             ];
         }, function(v){
             $('#morphId').val(v[0].trim());
@@ -389,6 +459,9 @@
             $('#morphSurfaceFeatures').val(v[8].trim());
             $('#morphPlutonium').val(v[9].trim());
             $('#morphNotes').val(v[10].trim());
+            $('#morphImageFile').val((v[11] || '').trim());
+            morphologyFileField.clearInput();
+            morphologyFileField.refresh();
         }, '/morphology/' + materialId + '/' + stage, function(){
             return {
                 id: $('#morphId').val(),
@@ -401,7 +474,8 @@
                 shape: $('#morphShape').val(),
                 surfaceFeatures: $('#morphSurfaceFeatures').val(),
                 plutoniumHomogeneity: $('#morphPlutonium').val(),
-                notes: $('#morphNotes').val()
+                notes: $('#morphNotes').val(),
+                imageFile: $('#morphImageFile').val()
             };
         });
 
@@ -464,6 +538,18 @@
 
         $('#addContainer').click(function(){ $('#containerStage').val(stage); });
 
+        var generalInfoFileField = createFileField('#generalImageFileInput', '#generalImageFile', '#generalImageFilePreview', '#generalImageFileClear');
+        $('#generalInfoDialog').on('dialogopen', function(){
+            if (!$('#generalId').val()) {
+                $('#generalImageFile').val('');
+            }
+            generalInfoFileField.clearInput();
+            generalInfoFileField.refresh();
+        }).on('dialogclose', function(){
+            generalInfoFileField.clearInput();
+            generalInfoFileField.refresh();
+        });
+
         init('#generalInfoDialog','#addGeneralInfo','#saveGeneralInfo','#generalInfoTable', function(){
             return [
                 $('#generalId').val(),
@@ -485,7 +571,8 @@
                 $('#generalVariationRangeNotes').val(),
                 $('#generalInformationAcquisitionDate').val(),
                 $('#generalUsedArchivedInformation').is(':checked'),
-                $('#generalNotes').val()
+                $('#generalNotes').val(),
+                $('#generalImageFile').val()
             ];
         }, function(v){
             $('#generalId').val(v[0].trim());
@@ -506,8 +593,11 @@
             $('#generalDataEvaluationInfo').val(v[15].trim());
             $('#generalVariationRangeNotes').val(v[16].trim());
             $('#generalInformationAcquisitionDate').val(v[17].trim());
-            $('#generalUsedArchivedInformation').prop('checked', v[18].trim().toLowerCase() === 'true');
+            $('#generalUsedArchivedInformation').prop('checked', (v[18] || '').trim().toLowerCase() === 'true');
             $('#generalNotes').val(v[19].trim());
+            $('#generalImageFile').val((v[20] || '').trim());
+            generalInfoFileField.clearInput();
+            generalInfoFileField.refresh();
         }, '/general-info/' + materialId + '/' + stage, function(){
             return {
                 id: $('#generalId').val(),
@@ -529,7 +619,8 @@
                 variationRangeNotes: $('#generalVariationRangeNotes').val(),
                 informationAcquisitionDate: $('#generalInformationAcquisitionDate').val(),
                 usedArchivedInformation: $('#generalUsedArchivedInformation').is(':checked'),
-                notes: $('#generalNotes').val()
+                notes: $('#generalNotes').val(),
+                imageFile: $('#generalImageFile').val()
             };
         });
 
@@ -800,6 +891,18 @@
             };
         });
 
+        var sourceDescriptionFileField = createFileField('#sourceDescriptionImageFileInput', '#sourceDescriptionImageFile', '#sourceDescriptionImageFilePreview', '#sourceDescriptionImageFileClear');
+        $('#sourceDescriptionDialog').on('dialogopen', function(){
+            if (!$('#sourceDescriptionId').val()) {
+                $('#sourceDescriptionImageFile').val('');
+            }
+            sourceDescriptionFileField.clearInput();
+            sourceDescriptionFileField.refresh();
+        }).on('dialogclose', function(){
+            sourceDescriptionFileField.clearInput();
+            sourceDescriptionFileField.refresh();
+        });
+
         init('#sourceDescriptionDialog','#addSourceDescription','#saveSourceDescription','#sourceDescriptionTable', function(){
             return [
                 $('#sourceDescriptionId').val(),
@@ -813,7 +916,8 @@
                 $('#sourceDescriptionShipping').val(),
                 $('#sourceDescriptionReceiving').val(),
                 $('#sourceDescriptionRadiograph').val(),
-                $('#sourceDescriptionNotes').val()
+                $('#sourceDescriptionNotes').val(),
+                $('#sourceDescriptionImageFile').val()
             ];
         }, function(v){
             $('#sourceDescriptionId').val(v[0].trim());
@@ -828,6 +932,9 @@
             $('#sourceDescriptionReceiving').val(v[9].trim());
             $('#sourceDescriptionRadiograph').val(v[10].trim());
             $('#sourceDescriptionNotes').val(v[11].trim());
+            $('#sourceDescriptionImageFile').val((v[12] || '').trim());
+            sourceDescriptionFileField.clearInput();
+            sourceDescriptionFileField.refresh();
         }, '/source-description/' + materialId + '/' + stage, function(){
             return {
                 id: $('#sourceDescriptionId').val(),
@@ -841,7 +948,8 @@
                 shippingHistory: $('#sourceDescriptionShipping').val(),
                 receivingHistory: $('#sourceDescriptionReceiving').val(),
                 radiographOrPhotograph: $('#sourceDescriptionRadiograph').val(),
-                notes: $('#sourceDescriptionNotes').val()
+                notes: $('#sourceDescriptionNotes').val(),
+                imageFile: $('#sourceDescriptionImageFile').val()
             };
         });
     });


### PR DESCRIPTION
## Summary
- add Image/PDF columns to the morphology, general information, and source description cards with links to view stored files
- extend the related dialogs with upload controls, preview links, and removal buttons that accept images or PDFs
- enhance the material form script with reusable file-field helpers and wire the imageFile property through the save/edit flows

## Testing
- mvn -q -DskipTests package *(fails: unable to reach Maven Central from the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ea0068d48333aa34f32cfec82a38