### PR TITLE
Handle file uploads for morphology, general info, and source description

### DIFF
--- a/src/main/java/io/sci/nnfl/web/GeneralInfoController.java
+++ b/src/main/java/io/sci/nnfl/web/GeneralInfoController.java
@@ -1,47 +1,67 @@
 package io.sci.nnfl.web;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.sci.nnfl.config.FileStorage;
 import io.sci.nnfl.model.GeneralInfo;
 import io.sci.nnfl.model.Material;
 import io.sci.nnfl.model.Stage;
 import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Controller
 @RequestMapping("/general-info")
 public class GeneralInfoController extends BaseController {
     private final MaterialRecordService service;
+    private final FileStorage storage;
+    private final ObjectMapper objectMapper;
 
-    public GeneralInfoController(MaterialRecordService service) {
+    public GeneralInfoController(MaterialRecordService service,
+                                 FileStorage storage,
+                                 ObjectMapper objectMapper) {
         this.service = service;
+        this.storage = storage;
+        this.objectMapper = objectMapper;
     }
 
-    @PostMapping("/{materialId}/{stage}")
+    @PostMapping(value = "/{materialId}/{stage}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
                                                     @PathVariable Integer stage,
                                                     @RequestBody GeneralInfo info) {
-        Material record = service.getById(materialId);
-        if (record.getGeneralInfo() == null) {
-            record.setGeneralInfo(new ArrayList<>());
+        return saveInternal(materialId, stage, info, null);
+    }
+
+    @PostMapping(value = "/{materialId}/{stage}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> saveWithFile(@PathVariable String materialId,
+                                                            @PathVariable Integer stage,
+                                                            @RequestPart(value = "payload", required = false) String payload,
+                                                            @RequestPart(value = "data", required = false) String data,
+                                                            @RequestPart(value = "file", required = false) MultipartFile file) {
+        String body = payload != null ? payload : data;
+        if (body == null) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Missing payload"));
         }
-        if (stage == null || stage < 0 || stage >= Stage.values().length) {
-            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        GeneralInfo info;
+        try {
+            info = objectMapper.readValue(body, GeneralInfo.class);
+        } catch (JsonProcessingException e) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid payload"));
         }
-        if (info.getId() == null || info.getId().isEmpty()) {
-            info.setId(UUID.randomUUID().toString());
-            info.setStage(Stage.values()[stage]);
-        }
-        record.getGeneralInfo().removeIf(g -> g.getId().equals(info.getId()));
-        record.getGeneralInfo().add(info);
-        service.save(record);
-        String redirect = "/materials/" + materialId + "/" + stage;
-        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+        return saveInternal(materialId, stage, info, file);
     }
 
     @PostMapping("/{materialId}/{stage}/{id}/delete")
@@ -50,6 +70,61 @@ public class GeneralInfoController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "generalInfo", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private ResponseEntity<Map<String, Object>> saveInternal(String materialId,
+                                                             Integer stageIndex,
+                                                             GeneralInfo info,
+                                                             MultipartFile file) {
+        Material record = service.getById(materialId);
+        if (record.getGeneralInfo() == null) {
+            record.setGeneralInfo(new ArrayList<>());
+        }
+        Optional<Stage> resolvedStage = resolveStage(stageIndex);
+        if (resolvedStage.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        Stage stage = resolvedStage.get();
+        if (info.getId() == null || info.getId().isEmpty()) {
+            info.setId(UUID.randomUUID().toString());
+            info.setStage(stage);
+        }
+        if (file != null && !file.isEmpty()) {
+            try {
+                var stored = storage.store(buildStorageKey(materialId, stage, "general-info", info.getId(), file), file);
+                info.setImageFile(stored.key());
+            } catch (IOException | URISyntaxException e) {
+                return ResponseEntity.internalServerError().body(Map.of("ok", false, "error", "Failed to store file"));
+            }
+        }
+        record.getGeneralInfo().removeIf(g -> g.getId().equals(info.getId()));
+        record.getGeneralInfo().add(info);
+        service.save(record);
+        String redirect = "/materials/" + materialId + "/" + stageIndex;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    private Optional<Stage> resolveStage(Integer stageIndex) {
+        if (stageIndex == null || stageIndex < 0 || stageIndex >= Stage.values().length) {
+            return Optional.empty();
+        }
+        return Optional.of(Stage.values()[stageIndex]);
+    }
+
+    private String buildStorageKey(String materialId,
+                                   Stage stage,
+                                   String section,
+                                   String entityId,
+                                   MultipartFile file) {
+        String originalFilename = Optional.ofNullable(file.getOriginalFilename()).orElse("file");
+        int dot = originalFilename.lastIndexOf('.');
+        String extension = dot >= 0 ? originalFilename.substring(dot) : "";
+        return String.format("materials/%s/%s/%s/%s%s",
+                materialId,
+                stage.name().toLowerCase(Locale.ROOT),
+                section,
+                entityId,
+                extension);
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/MorphologyController.java
+++ b/src/main/java/io/sci/nnfl/web/MorphologyController.java
@@ -1,47 +1,67 @@
 package io.sci.nnfl.web;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.sci.nnfl.config.FileStorage;
 import io.sci.nnfl.model.Material;
 import io.sci.nnfl.model.Morphology;
 import io.sci.nnfl.model.Stage;
 import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Controller
 @RequestMapping("/morphology")
 public class MorphologyController extends BaseController {
     private final MaterialRecordService service;
+    private final FileStorage storage;
+    private final ObjectMapper objectMapper;
 
-    public MorphologyController(MaterialRecordService service) {
+    public MorphologyController(MaterialRecordService service,
+                                FileStorage storage,
+                                ObjectMapper objectMapper) {
         this.service = service;
+        this.storage = storage;
+        this.objectMapper = objectMapper;
     }
 
-    @PostMapping("/{materialId}/{stage}")
+    @PostMapping(value = "/{materialId}/{stage}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
                                                     @PathVariable Integer stage,
                                                     @RequestBody Morphology morphology) {
-        Material record = service.getById(materialId);
-        if (record.getMorphologies() == null) {
-            record.setMorphologies(new ArrayList<>());
+        return saveInternal(materialId, stage, morphology, null);
+    }
+
+    @PostMapping(value = "/{materialId}/{stage}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> saveWithFile(@PathVariable String materialId,
+                                                            @PathVariable Integer stage,
+                                                            @RequestPart(value = "payload", required = false) String payload,
+                                                            @RequestPart(value = "data", required = false) String data,
+                                                            @RequestPart(value = "file", required = false) MultipartFile file) {
+        String body = payload != null ? payload : data;
+        if (body == null) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Missing payload"));
         }
-        if (stage == null || stage < 0 || stage >= Stage.values().length) {
-            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        Morphology morphology;
+        try {
+            morphology = objectMapper.readValue(body, Morphology.class);
+        } catch (JsonProcessingException e) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid payload"));
         }
-        if (morphology.getId() == null || morphology.getId().isEmpty()) {
-            morphology.setId(UUID.randomUUID().toString());
-            morphology.setStage(Stage.values()[stage]);
-        }
-        record.getMorphologies().removeIf(m -> m.getId().equals(morphology.getId()));
-        record.getMorphologies().add(morphology);
-        service.save(record);
-        String redirect = "/materials/" + materialId + "/" + stage;
-        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+        return saveInternal(materialId, stage, morphology, file);
     }
 
     @PostMapping("/{materialId}/{stage}/{id}/delete")
@@ -50,6 +70,61 @@ public class MorphologyController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "morphologies", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private ResponseEntity<Map<String, Object>> saveInternal(String materialId,
+                                                             Integer stageIndex,
+                                                             Morphology morphology,
+                                                             MultipartFile file) {
+        Material record = service.getById(materialId);
+        if (record.getMorphologies() == null) {
+            record.setMorphologies(new ArrayList<>());
+        }
+        Optional<Stage> resolvedStage = resolveStage(stageIndex);
+        if (resolvedStage.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        Stage stage = resolvedStage.get();
+        if (morphology.getId() == null || morphology.getId().isEmpty()) {
+            morphology.setId(UUID.randomUUID().toString());
+            morphology.setStage(stage);
+        }
+        if (file != null && !file.isEmpty()) {
+            try {
+                var stored = storage.store(buildStorageKey(materialId, stage, "morphology", morphology.getId(), file), file);
+                morphology.setImageFile(stored.key());
+            } catch (IOException | URISyntaxException e) {
+                return ResponseEntity.internalServerError().body(Map.of("ok", false, "error", "Failed to store file"));
+            }
+        }
+        record.getMorphologies().removeIf(m -> m.getId().equals(morphology.getId()));
+        record.getMorphologies().add(morphology);
+        service.save(record);
+        String redirect = "/materials/" + materialId + "/" + stageIndex;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    private Optional<Stage> resolveStage(Integer stageIndex) {
+        if (stageIndex == null || stageIndex < 0 || stageIndex >= Stage.values().length) {
+            return Optional.empty();
+        }
+        return Optional.of(Stage.values()[stageIndex]);
+    }
+
+    private String buildStorageKey(String materialId,
+                                   Stage stage,
+                                   String section,
+                                   String entityId,
+                                   MultipartFile file) {
+        String originalFilename = Optional.ofNullable(file.getOriginalFilename()).orElse("file");
+        int dot = originalFilename.lastIndexOf('.');
+        String extension = dot >= 0 ? originalFilename.substring(dot) : "";
+        return String.format("materials/%s/%s/%s/%s%s",
+                materialId,
+                stage.name().toLowerCase(Locale.ROOT),
+                section,
+                entityId,
+                extension);
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/SourceDescriptionController.java
+++ b/src/main/java/io/sci/nnfl/web/SourceDescriptionController.java
@@ -1,47 +1,67 @@
 package io.sci.nnfl.web;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.sci.nnfl.config.FileStorage;
 import io.sci.nnfl.model.Material;
 import io.sci.nnfl.model.SourceDescription;
 import io.sci.nnfl.model.Stage;
 import io.sci.nnfl.service.MaterialRecordService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Controller
 @RequestMapping("/source-description")
 public class SourceDescriptionController extends BaseController {
     private final MaterialRecordService service;
+    private final FileStorage storage;
+    private final ObjectMapper objectMapper;
 
-    public SourceDescriptionController(MaterialRecordService service) {
+    public SourceDescriptionController(MaterialRecordService service,
+                                       FileStorage storage,
+                                       ObjectMapper objectMapper) {
         this.service = service;
+        this.storage = storage;
+        this.objectMapper = objectMapper;
     }
 
-    @PostMapping("/{materialId}/{stage}")
+    @PostMapping(value = "/{materialId}/{stage}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Map<String, Object>> save(@PathVariable String materialId,
                                                     @PathVariable Integer stage,
                                                     @RequestBody SourceDescription description) {
-        Material record = service.getById(materialId);
-        if (record.getSourceDescriptions() == null) {
-            record.setSourceDescriptions(new ArrayList<>());
+        return saveInternal(materialId, stage, description, null);
+    }
+
+    @PostMapping(value = "/{materialId}/{stage}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> saveWithFile(@PathVariable String materialId,
+                                                            @PathVariable Integer stage,
+                                                            @RequestPart(value = "payload", required = false) String payload,
+                                                            @RequestPart(value = "data", required = false) String data,
+                                                            @RequestPart(value = "file", required = false) MultipartFile file) {
+        String body = payload != null ? payload : data;
+        if (body == null) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Missing payload"));
         }
-        if (stage == null || stage < 0 || stage >= Stage.values().length) {
-            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        SourceDescription description;
+        try {
+            description = objectMapper.readValue(body, SourceDescription.class);
+        } catch (JsonProcessingException e) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid payload"));
         }
-        if (description.getId() == null || description.getId().isEmpty()) {
-            description.setId(UUID.randomUUID().toString());
-            description.setStage(Stage.values()[stage]);
-        }
-        record.getSourceDescriptions().removeIf(s -> s.getId().equals(description.getId()));
-        record.getSourceDescriptions().add(description);
-        service.save(record);
-        String redirect = "/materials/" + materialId + "/" + stage;
-        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+        return saveInternal(materialId, stage, description, file);
     }
 
     @PostMapping("/{materialId}/{stage}/{id}/delete")
@@ -50,6 +70,61 @@ public class SourceDescriptionController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "sourceDescriptions", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private ResponseEntity<Map<String, Object>> saveInternal(String materialId,
+                                                             Integer stageIndex,
+                                                             SourceDescription description,
+                                                             MultipartFile file) {
+        Material record = service.getById(materialId);
+        if (record.getSourceDescriptions() == null) {
+            record.setSourceDescriptions(new ArrayList<>());
+        }
+        Optional<Stage> resolvedStage = resolveStage(stageIndex);
+        if (resolvedStage.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
+        }
+        Stage stage = resolvedStage.get();
+        if (description.getId() == null || description.getId().isEmpty()) {
+            description.setId(UUID.randomUUID().toString());
+            description.setStage(stage);
+        }
+        if (file != null && !file.isEmpty()) {
+            try {
+                var stored = storage.store(buildStorageKey(materialId, stage, "source-description", description.getId(), file), file);
+                description.setImageFile(stored.key());
+            } catch (IOException | URISyntaxException e) {
+                return ResponseEntity.internalServerError().body(Map.of("ok", false, "error", "Failed to store file"));
+            }
+        }
+        record.getSourceDescriptions().removeIf(s -> s.getId().equals(description.getId()));
+        record.getSourceDescriptions().add(description);
+        service.save(record);
+        String redirect = "/materials/" + materialId + "/" + stageIndex;
+        return ResponseEntity.ok(Map.of("ok", true, "redirectUrl", redirect));
+    }
+
+    private Optional<Stage> resolveStage(Integer stageIndex) {
+        if (stageIndex == null || stageIndex < 0 || stageIndex >= Stage.values().length) {
+            return Optional.empty();
+        }
+        return Optional.of(Stage.values()[stageIndex]);
+    }
+
+    private String buildStorageKey(String materialId,
+                                   Stage stage,
+                                   String section,
+                                   String entityId,
+                                   MultipartFile file) {
+        String originalFilename = Optional.ofNullable(file.getOriginalFilename()).orElse("file");
+        int dot = originalFilename.lastIndexOf('.');
+        String extension = dot >= 0 ? originalFilename.substring(dot) : "";
+        return String.format("materials/%s/%s/%s/%s%s",
+                materialId,
+                stage.name().toLowerCase(Locale.ROOT),
+                section,
+                entityId,
+                extension);
     }
 }
 


### PR DESCRIPTION
## Summary
- update the morphology, general info, and source description controllers to accept multipart form payloads alongside existing JSON requests
- persist uploaded files through the shared FileStorage service and capture stored keys on the corresponding `imageFile` fields
- add helper logic for stage validation and storage key generation to reuse across save flows

## Testing
- mvn -q -DskipTests compile *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f94aa9cc833392659cee8b02e59c