### PR TITLE
Refactor material form uploads to use multipart

### DIFF
--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -116,7 +116,8 @@
         var csrfToken = document.querySelector('meta[name="_csrf"]')?.getAttribute('content');
         var csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.getAttribute('content');
 
-        function init(dialogId, addBtnId, saveBtnId, tableId, getData, setData, endpoint, getJsonData){
+        function init(dialogId, addBtnId, saveBtnId, tableId, getData, setData, endpoint, getJsonData, options){
+            options = options || {};
             var currentRow = null;
             $(dialogId).dialog({ autoOpen:false, modal:true, width:640 });
             $(addBtnId).click(function(){ currentRow=null; $(dialogId).dialog('open'); });
@@ -129,16 +130,33 @@
             $(saveBtnId).click(function(){
                 var data = getData();
                 var payload = getJsonData ? getJsonData() : data;
-                var headers = {'Content-Type':'application/json'};
-                if (csrfToken) {
-                    headers[csrfHeader || 'X-CSRF-TOKEN'] = csrfToken;
-                }
-                fetch(endpoint, {
+                var fileInput = options.fileInput ? document.querySelector(options.fileInput) : null;
+                var hasFile = fileInput && fileInput.files && fileInput.files.length > 0;
+                var fetchOptions = {
                     method: 'POST',
-                    headers: headers,
-                    body: JSON.stringify(payload),
                     credentials: 'same-origin'
-                })
+                };
+                var headers = {};
+                if (hasFile) {
+                    var formData = new FormData();
+                    formData.append(options.payloadField || 'payload', JSON.stringify(payload));
+                    formData.append(options.fileField || 'file', fileInput.files[0]);
+                    if (csrfToken) {
+                        headers[csrfHeader || 'X-CSRF-TOKEN'] = csrfToken;
+                    }
+                    if (Object.keys(headers).length > 0) {
+                        fetchOptions.headers = headers;
+                    }
+                    fetchOptions.body = formData;
+                } else {
+                    headers['Content-Type'] = 'application/json';
+                    if (csrfToken) {
+                        headers[csrfHeader || 'X-CSRF-TOKEN'] = csrfToken;
+                    }
+                    fetchOptions.headers = headers;
+                    fetchOptions.body = JSON.stringify(payload);
+                }
+                fetch(endpoint, fetchOptions)
                     .then(res => {
                         if (res.ok) {               // server sent 3xx (e.g., 303 See Other)
                             window.location.reload();
@@ -163,11 +181,23 @@
             var $clearButton = clearSelector ? $(clearSelector) : null;
             var defaultText = $previewLink.text() || 'View file';
 
-            function updateControls(fileName) {
+            function updateControls() {
+                var fileElement = $fileInput.get(0);
+                if (fileElement && fileElement.files && fileElement.files.length > 0) {
+                    var name = fileElement.files[0].name;
+                    $previewLink.removeAttr('href')
+                        .text('Selected file: ' + name)
+                        .show();
+                    if ($clearButton) {
+                        $clearButton.show();
+                    }
+                    return;
+                }
+
                 var value = $hiddenInput.val();
                 if (value) {
                     $previewLink.attr('href', value)
-                        .text(fileName || defaultText)
+                        .text(defaultText)
                         .show();
                     if ($clearButton) {
                         $clearButton.show();
@@ -193,16 +223,7 @@
             }
 
             $fileInput.on('change', function(){
-                var file = this.files && this.files[0];
-                if (!file) {
-                    return;
-                }
-                var reader = new FileReader();
-                reader.onload = function(event){
-                    $hiddenInput.val(event.target.result);
-                    updateControls(file.name);
-                };
-                reader.readAsDataURL(file);
+                updateControls();
             });
 
             updateControls();
@@ -477,7 +498,7 @@
                 notes: $('#morphNotes').val(),
                 imageFile: $('#morphImageFile').val()
             };
-        });
+        }, { fileInput: '#morphImageFileInput' });
 
         init('#uraniumDecayDialog','#addUraniumDecay','#saveUraniumDecay','#uraniumDecayTable', function(){
             return [
@@ -622,7 +643,7 @@
                 notes: $('#generalNotes').val(),
                 imageFile: $('#generalImageFile').val()
             };
-        });
+        }, { fileInput: '#generalImageFileInput' });
 
         init('#geologyDialog','#addGeology','#saveGeology','#geologyTable', function(){
             return [
@@ -951,7 +972,7 @@
                 notes: $('#sourceDescriptionNotes').val(),
                 imageFile: $('#sourceDescriptionImageFile').val()
             };
-        });
+        }, { fileInput: '#sourceDescriptionImageFileInput' });
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add optional multipart support to the shared dialog helper so file uploads send FormData and JSON-only dialogs keep their existing workflow
- rework the reusable file control to show the selected filename instead of embedding a Base64 payload
- hook the general info, morphology, and source description dialogs into the new multipart flow so the backend receives real MultipartFile parts

## Testing
- mvn -q test *(fails: unable to resolve Spring Boot parent POM because repo.maven.apache.org is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fd1de42883338cb8c7ba1eaac129