### PR TITLE
Improve local file controller handling

### DIFF
--- a/src/main/java/io/sci/nnfl/api/LocalFileController.java
+++ b/src/main/java/io/sci/nnfl/api/LocalFileController.java
@@ -2,18 +2,21 @@ package io.sci.nnfl.api;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.BufferedInputStream;
-import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 
 @RestController
 @RequestMapping("/file")
@@ -25,20 +28,33 @@ public class LocalFileController {
     @RequestMapping(value = "/{fileName:.+}", method = RequestMethod.GET)
     public ResponseEntity<byte[]> getImage(@PathVariable("fileName") String fileName) {
         HttpHeaders headers = new HttpHeaders();
-        DataInputStream in;
+        Path basePath = Paths.get(location).toAbsolutePath().normalize();
+        Path requestedFile = basePath.resolve(fileName).normalize();
+
         try {
-            File file = new File(location+"/"+fileName);
-            byte[] media = new byte[(int) file.length()];
-            BufferedInputStream br = new BufferedInputStream(new FileInputStream(file));
-            br.read(media);
+            if (!requestedFile.startsWith(basePath) || !Files.exists(requestedFile) || !Files.isRegularFile(requestedFile)) {
+                return new ResponseEntity<>(null, headers, HttpStatus.NOT_FOUND);
+            }
+
+            byte[] media = Files.readAllBytes(requestedFile);
 
             headers.setCacheControl(CacheControl.noCache().getHeaderValue());
-            ResponseEntity<byte[]> responseEntity = new ResponseEntity<>(media, headers, HttpStatus.OK);
-            return responseEntity;
+
+            String contentType = Files.probeContentType(requestedFile);
+            if (contentType != null && !contentType.isBlank()) {
+                headers.setContentType(MediaType.parseMediaType(contentType));
+            } else {
+                headers.setContentType(APPLICATION_OCTET_STREAM);
+            }
+
+            headers.setContentDisposition(ContentDisposition.inline()
+                    .filename(requestedFile.getFileName().toString())
+                    .build());
+
+            return new ResponseEntity<>(media, headers, HttpStatus.OK);
 
         } catch (Exception e) {
-            ResponseEntity<byte[]> responseEntity = new ResponseEntity<>(null, headers, HttpStatus.BAD_REQUEST);
-            return responseEntity;
+            return new ResponseEntity<>(null, headers, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure files requested from the local file controller are resolved within the configured base path
- read file contents with NIO utilities and set appropriate response headers for inline display/download
- fall back to sensible defaults and error responses when the file is missing or an I/O error occurs

## Testing
- mvn -q -DskipTests compile *(fails: Non-resolvable parent POM due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d108badca8833397f5315b1130e128