### PR TITLE
Add magnification support to morphology and sanitize inputs

### DIFF
--- a/src/main/java/io/sci/nnfl/model/Morphology.java
+++ b/src/main/java/io/sci/nnfl/model/Morphology.java
@@ -4,12 +4,15 @@ import com.google.gson.annotations.Expose;
 import lombok.*;
 import org.springframework.data.annotation.Transient;
 
+import java.math.BigDecimal;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Morphology extends Property {
+    @Expose private BigDecimal magnification;
     @Expose private String latticeStructure;
     @Expose private String aspectRatio;
     @Expose private String porosity;

--- a/src/main/java/io/sci/nnfl/web/MorphologyController.java
+++ b/src/main/java/io/sci/nnfl/web/MorphologyController.java
@@ -10,6 +10,7 @@ import io.sci.nnfl.service.MaterialRecordService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -89,6 +90,7 @@ public class MorphologyController extends BaseController {
             morphology.setId(UUID.randomUUID().toString());
             morphology.setStage(stage);
         }
+        sanitizeMorphology(morphology);
         if (file != null && !file.isEmpty()) {
             try {
                 var stored = storage.store(buildStorageKey(materialId, stage, "crystallography", morphology.getId(), file), file);
@@ -125,6 +127,26 @@ public class MorphologyController extends BaseController {
                 section,
                 entityId,
                 extension);
+    }
+
+    private void sanitizeMorphology(Morphology morphology) {
+        morphology.setLatticeStructure(trimToNull(morphology.getLatticeStructure()));
+        morphology.setAspectRatio(trimToNull(morphology.getAspectRatio()));
+        morphology.setPorosity(trimToNull(morphology.getPorosity()));
+        morphology.setColour(trimToNull(morphology.getColour()));
+        morphology.setParticleSizeAndDistribution(trimToNull(morphology.getParticleSizeAndDistribution()));
+        morphology.setShape(trimToNull(morphology.getShape()));
+        morphology.setSurfaceFeatures(trimToNull(morphology.getSurfaceFeatures()));
+        morphology.setPlutoniumHomogeneity(trimToNull(morphology.getPlutoniumHomogeneity()));
+        morphology.setNotes(trimToNull(morphology.getNotes()));
+        morphology.setImageFile(trimToNull(morphology.getImageFile()));
+    }
+
+    private String trimToNull(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
     }
 }
 

--- a/src/main/resources/templates/cards/morphology.html
+++ b/src/main/resources/templates/cards/morphology.html
@@ -11,6 +11,7 @@
                     <tr>
                         <th style="width:0%"><span class="kt-table-col"><span class="kt-table-col-label" hidden>ID</span></span></th>
                         <th style="width:5%"><span class="kt-table-col"><span class="kt-table-col-label">Stage</span></span></th>
+                        <th><span class="kt-table-col"><span class="kt-table-col-label">Magnification</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Lattice Structure</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Aspect Ratio</span></span></th>
                         <th><span class="kt-table-col"><span class="kt-table-col-label">Porosity</span></span></th>
@@ -28,6 +29,7 @@
                     <tr>
                         <td><div><span th:text="${morph.id}" hidden></span></div></td>
                         <td><span th:text="${morph.stage}"></span></td>
+                        <td><span th:text="${morph.magnification}"></span></td>
                         <td><span th:text="${morph.latticeStructure}"></span></td>
                         <td><span th:text="${morph.aspectRatio}"></span></td>
                         <td><span th:text="${morph.porosity}"></span></td>

--- a/src/main/resources/templates/dialogs/morphology.html
+++ b/src/main/resources/templates/dialogs/morphology.html
@@ -10,6 +10,10 @@
             <input class="kt-input" id="morphStage" disabled type="text"/>
         </div>
         <div class="flex items-baseline gap-2.5">
+            <label class="kt-form-label max-w-56">Magnification :</label>
+            <input class="kt-input" id="morphMagnification" type="number" step="any"/>
+        </div>
+        <div class="flex items-baseline gap-2.5">
             <label class="kt-form-label max-w-56">Lattice Structure :</label>
             <input class="kt-input" id="morphLatticeStructure" type="text"/>
         </div>

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -116,6 +116,18 @@
         var csrfToken = document.querySelector('meta[name="_csrf"]')?.getAttribute('content');
         var csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.getAttribute('content');
 
+        function parseDecimalOrNull(value) {
+            if (value === undefined || value === null) {
+                return null;
+            }
+            var trimmed = ('' + value).trim();
+            if (trimmed === '') {
+                return null;
+            }
+            var parsed = parseFloat(trimmed);
+            return isNaN(parsed) ? null : parsed;
+        }
+
         function init(dialogId, addBtnId, saveBtnId, tableId, getData, setData, endpoint, getJsonData, options){
             options = options || {};
             var currentRow = null;
@@ -454,6 +466,7 @@
             return [
                 $('#morphId').val(),
                 $('#morphStage').val() || stage,
+                $('#morphMagnification').val(),
                 $('#morphLatticeStructure').val(),
                 $('#morphAspectRatio').val(),
                 $('#morphPorosity').val(),
@@ -468,22 +481,24 @@
         }, function(v){
             $('#morphId').val(v[0].trim());
             $('#morphStage').val(v[1].trim());
-            $('#morphLatticeStructure').val(v[2].trim());
-            $('#morphAspectRatio').val(v[3].trim());
-            $('#morphPorosity').val(v[4].trim());
-            $('#morphColour').val(v[5].trim());
-            $('#morphParticle').val(v[6].trim());
-            $('#morphShape').val(v[7].trim());
-            $('#morphSurfaceFeatures').val(v[8].trim());
-            $('#morphPlutonium').val(v[9].trim());
-            $('#morphNotes').val(v[10].trim());
-            $('#morphImageFile').val((v[11] || '').trim());
+            $('#morphMagnification').val(v[2].trim());
+            $('#morphLatticeStructure').val(v[3].trim());
+            $('#morphAspectRatio').val(v[4].trim());
+            $('#morphPorosity').val(v[5].trim());
+            $('#morphColour').val(v[6].trim());
+            $('#morphParticle').val(v[7].trim());
+            $('#morphShape').val(v[8].trim());
+            $('#morphSurfaceFeatures').val(v[9].trim());
+            $('#morphPlutonium').val(v[10].trim());
+            $('#morphNotes').val(v[11].trim());
+            $('#morphImageFile').val((v[12] || '').trim());
             morphologyFileField.clearInput();
             morphologyFileField.refresh();
         }, '/morphology/' + materialId + '/' + stage, function(){
             return {
                 id: $('#morphId').val(),
                 stage: $('#morphStage').val() || stage,
+                magnification: parseDecimalOrNull($('#morphMagnification').val()),
                 latticeStructure: $('#morphLatticeStructure').val(),
                 aspectRatio: $('#morphAspectRatio').val(),
                 porosity: $('#morphPorosity').val(),


### PR DESCRIPTION
## Summary
- add a BigDecimal magnification field to the morphology model and expose it in the UI
- update the morphology dialog, table, and client-side parsing to capture magnification values without forcing 0.0 defaults
- sanitize morphology payloads on the server so empty-string attributes are stored as nulls

## Testing
- mvn -q -DskipTests package *(fails: missing parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1224fd9cc8333b97f751211fda79f