### PR TITLE
Sanitize controller inputs and improve numeric parsing

### DIFF
--- a/src/main/java/io/sci/nnfl/web/ChemicalFormController.java
+++ b/src/main/java/io/sci/nnfl/web/ChemicalFormController.java
@@ -34,6 +34,7 @@ public class ChemicalFormController extends BaseController{
         if (stage==null || stage < 0 || stage>10){
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeChemicalForm(chemicalForm);
         if (chemicalForm.getId() == null || chemicalForm.getId().isEmpty()) {
             chemicalForm.setId(UUID.randomUUID().toString());
             chemicalForm.setStage(Stage.values()[stage]);
@@ -64,5 +65,10 @@ public class ChemicalFormController extends BaseController{
                                      @PathVariable("id") String id) {
         service.removeProperty(materialId, "chemicalForms", id);
         return "redirect:/materials/"+materialId+"/"+stage;
+    }
+
+    private void sanitizeChemicalForm(ChemicalForm chemicalForm) {
+        chemicalForm.setCompoundName(trimToNull(chemicalForm.getCompoundName()));
+        chemicalForm.setNotes(trimToNull(chemicalForm.getNotes()));
     }
 }

--- a/src/main/java/io/sci/nnfl/web/ContainerController.java
+++ b/src/main/java/io/sci/nnfl/web/ContainerController.java
@@ -33,6 +33,7 @@ public class ContainerController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeContainer(container);
         if (container.getId() == null || container.getId().isEmpty()) {
             container.setId(UUID.randomUUID().toString());
             container.setStage(Stage.values()[stage]);
@@ -50,6 +51,13 @@ public class ContainerController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "containers", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeContainer(Container container) {
+        container.setType(trimToNull(container.getType()));
+        container.setVolumeUnit(trimToNull(container.getVolumeUnit()));
+        container.setDimensions(trimToNull(container.getDimensions()));
+        container.setNotes(trimToNull(container.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/DecayController.java
+++ b/src/main/java/io/sci/nnfl/web/DecayController.java
@@ -33,6 +33,7 @@ public class DecayController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeDecay(decay);
         if (decay.getId() == null || decay.getId().isEmpty()) {
             decay.setId(UUID.randomUUID().toString());
             decay.setStage(Stage.values()[stage]);
@@ -50,6 +51,11 @@ public class DecayController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "uraniumDecaySeriesRadionuclides", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeDecay(UraniumDecaySeriesRadionuclide decay) {
+        decay.setIsotopeName(trimToNull(decay.getIsotopeName()));
+        decay.setNotes(trimToNull(decay.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/ElementController.java
+++ b/src/main/java/io/sci/nnfl/web/ElementController.java
@@ -33,6 +33,7 @@ public class ElementController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeElement(element);
         if (element.getId() == null || element.getId().isEmpty()) {
             element.setId(UUID.randomUUID().toString());
             element.setStage(Stage.values()[stage]);
@@ -50,6 +51,13 @@ public class ElementController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "elemental", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeElement(Element element) {
+        element.setElement(trimToNull(element.getElement()));
+        element.setUnit(trimToNull(element.getUnit()));
+        element.setBurnablePoison(trimToNull(element.getBurnablePoison()));
+        element.setNotes(trimToNull(element.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/GeneralInfoController.java
+++ b/src/main/java/io/sci/nnfl/web/GeneralInfoController.java
@@ -85,6 +85,7 @@ public class GeneralInfoController extends BaseController {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
         Stage stage = resolvedStage.get();
+        sanitizeGeneralInfo(info);
         if (info.getId() == null || info.getId().isEmpty()) {
             info.setId(UUID.randomUUID().toString());
             info.setStage(stage);
@@ -125,6 +126,21 @@ public class GeneralInfoController extends BaseController {
                 section,
                 entityId,
                 extension);
+    }
+
+    private void sanitizeGeneralInfo(GeneralInfo info) {
+        info.setCustodian(trimToNull(info.getCustodian()));
+        info.setAnalyticalLab(trimToNull(info.getAnalyticalLab()));
+        info.setCountryOfOrigin(trimToNull(info.getCountryOfOrigin()));
+        info.setProducer(trimToNull(info.getProducer()));
+        info.setSupplier(trimToNull(info.getSupplier()));
+        info.setBatchId(trimToNull(info.getBatchId()));
+        info.setShipperCarrier(trimToNull(info.getShipperCarrier()));
+        info.setReceiverInfo(trimToNull(info.getReceiverInfo()));
+        info.setDataEvaluationInfo(trimToNull(info.getDataEvaluationInfo()));
+        info.setVariationRangeNotes(trimToNull(info.getVariationRangeNotes()));
+        info.setNotes(trimToNull(info.getNotes()));
+        info.setImageFile(trimToNull(info.getImageFile()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/GeologyController.java
+++ b/src/main/java/io/sci/nnfl/web/GeologyController.java
@@ -33,6 +33,7 @@ public class GeologyController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeGeology(geology);
         if (geology.getId() == null || geology.getId().isEmpty()) {
             geology.setId(UUID.randomUUID().toString());
             geology.setStage(Stage.values()[stage]);
@@ -50,6 +51,15 @@ public class GeologyController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "geology", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeGeology(Geology geology) {
+        geology.setMineLocation(trimToNull(geology.getMineLocation()));
+        geology.setGeologicalFormation(trimToNull(geology.getGeologicalFormation()));
+        geology.setDepositTypes(trimToNull(geology.getDepositTypes()));
+        geology.setMiningTechnique(trimToNull(geology.getMiningTechnique()));
+        geology.setColour(trimToNull(geology.getColour()));
+        geology.setNotes(trimToNull(geology.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/IrradiationController.java
+++ b/src/main/java/io/sci/nnfl/web/IrradiationController.java
@@ -33,6 +33,7 @@ public class IrradiationController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeIrradiation(irradiation);
         if (irradiation.getId() == null || irradiation.getId().isEmpty()) {
             irradiation.setId(UUID.randomUUID().toString());
             irradiation.setStage(Stage.values()[stage]);
@@ -50,6 +51,15 @@ public class IrradiationController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "irradiationHistories", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeIrradiation(IrradiationHistory irradiation) {
+        irradiation.setReactorType(trimToNull(irradiation.getReactorType()));
+        irradiation.setBurnUp(trimToNull(irradiation.getBurnUp()));
+        irradiation.setAssemblyPowerHistory(trimToNull(irradiation.getAssemblyPowerHistory()));
+        irradiation.setOperatingRecordsRef(trimToNull(irradiation.getOperatingRecordsRef()));
+        irradiation.setRadiationLevel(trimToNull(irradiation.getRadiationLevel()));
+        irradiation.setNotes(trimToNull(irradiation.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/IsotopeActivityController.java
+++ b/src/main/java/io/sci/nnfl/web/IsotopeActivityController.java
@@ -33,6 +33,7 @@ public class IsotopeActivityController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeIsotopeActivity(activity);
         if (activity.getId() == null || activity.getId().isEmpty()) {
             activity.setId(UUID.randomUUID().toString());
             activity.setStage(Stage.values()[stage]);
@@ -50,6 +51,11 @@ public class IsotopeActivityController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "isotopeActivities", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeIsotopeActivity(IsotopeActivity activity) {
+        activity.setIsotopeName(trimToNull(activity.getIsotopeName()));
+        activity.setNotes(trimToNull(activity.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/MineralogyController.java
+++ b/src/main/java/io/sci/nnfl/web/MineralogyController.java
@@ -33,6 +33,7 @@ public class MineralogyController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeMineralogy(mineralogy);
         if (mineralogy.getId() == null || mineralogy.getId().isEmpty()) {
             mineralogy.setId(UUID.randomUUID().toString());
             mineralogy.setStage(Stage.values()[stage]);
@@ -50,6 +51,13 @@ public class MineralogyController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "mineralogy", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeMineralogy(Mineralogy mineralogy) {
+        mineralogy.setMineralsPresent(trimToNull(mineralogy.getMineralsPresent()));
+        mineralogy.setMineralChemistry(trimToNull(mineralogy.getMineralChemistry()));
+        mineralogy.setVolumePercentages(trimToNull(mineralogy.getVolumePercentages()));
+        mineralogy.setNotes(trimToNull(mineralogy.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/PhysicalController.java
+++ b/src/main/java/io/sci/nnfl/web/PhysicalController.java
@@ -33,6 +33,7 @@ public class PhysicalController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizePhysical(physical);
         if (physical.getId() == null || physical.getId().isEmpty()) {
             physical.setId(UUID.randomUUID().toString());
             physical.setStage(Stage.values()[stage]);
@@ -50,6 +51,20 @@ public class PhysicalController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "physicals", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizePhysical(Physical physical) {
+        physical.setDensityUnit(trimToNull(physical.getDensityUnit()));
+        physical.setStateOfMatter(trimToNull(physical.getStateOfMatter()));
+        physical.setMechanicalProperties(trimToNull(physical.getMechanicalProperties()));
+        physical.setDescription(trimToNull(physical.getDescription()));
+        physical.setDimensions(trimToNull(physical.getDimensions()));
+        physical.setCladdingInfo(trimToNull(physical.getCladdingInfo()));
+        physical.setCoatingInfo(trimToNull(physical.getCoatingInfo()));
+        physical.setAssemblyStructure(trimToNull(physical.getAssemblyStructure()));
+        physical.setSurfaceOxideThickness(trimToNull(physical.getSurfaceOxideThickness()));
+        physical.setSerialNumbers(trimToNull(physical.getSerialNumbers()));
+        physical.setNotes(trimToNull(physical.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/PlutoniumIsotopeController.java
+++ b/src/main/java/io/sci/nnfl/web/PlutoniumIsotopeController.java
@@ -33,6 +33,7 @@ public class PlutoniumIsotopeController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeIsotopeRatio(isotope);
         if (isotope.getId() == null || isotope.getId().isEmpty()) {
             isotope.setId(UUID.randomUUID().toString());
             isotope.setStage(Stage.values()[stage]);
@@ -50,6 +51,12 @@ public class PlutoniumIsotopeController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "plutoniumIsotopes", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeIsotopeRatio(IsotopeRatio isotope) {
+        isotope.setName(trimToNull(isotope.getName()));
+        isotope.setUnit(trimToNull(isotope.getUnit()));
+        isotope.setNotes(trimToNull(isotope.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/ProcessInfoController.java
+++ b/src/main/java/io/sci/nnfl/web/ProcessInfoController.java
@@ -33,6 +33,7 @@ public class ProcessInfoController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeProcessInformation(info);
         if (info.getId() == null || info.getId().isEmpty()) {
             info.setId(UUID.randomUUID().toString());
             info.setStage(Stage.values()[stage]);
@@ -50,6 +51,12 @@ public class ProcessInfoController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "processInformation", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeProcessInformation(ProcessInformation info) {
+        info.setProcessTypeOrDescription(trimToNull(info.getProcessTypeOrDescription()));
+        info.setLocationOfProcessingSite(trimToNull(info.getLocationOfProcessingSite()));
+        info.setNotes(trimToNull(info.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/SerialNumberController.java
+++ b/src/main/java/io/sci/nnfl/web/SerialNumberController.java
@@ -33,6 +33,7 @@ public class SerialNumberController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeSerialNumber(serial);
         if (serial.getId() == null || serial.getId().isEmpty()) {
             serial.setId(UUID.randomUUID().toString());
             serial.setStage(Stage.values()[stage]);
@@ -50,6 +51,11 @@ public class SerialNumberController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "serialNumbers", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeSerialNumber(SerialNumber serial) {
+        serial.setSerialNumber(trimToNull(serial.getSerialNumber()));
+        serial.setNotes(trimToNull(serial.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/SourceActivityInfoController.java
+++ b/src/main/java/io/sci/nnfl/web/SourceActivityInfoController.java
@@ -33,6 +33,7 @@ public class SourceActivityInfoController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeSourceActivityInfo(info);
         if (info.getId() == null || info.getId().isEmpty()) {
             info.setId(UUID.randomUUID().toString());
             info.setStage(Stage.values()[stage]);
@@ -50,6 +51,10 @@ public class SourceActivityInfoController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "sourceActivityInfo", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeSourceActivityInfo(SourceActivityInfo info) {
+        info.setNotes(trimToNull(info.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/SourceDescriptionController.java
+++ b/src/main/java/io/sci/nnfl/web/SourceDescriptionController.java
@@ -85,6 +85,7 @@ public class SourceDescriptionController extends BaseController {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
         Stage stage = resolvedStage.get();
+        sanitizeSourceDescription(description);
         if (description.getId() == null || description.getId().isEmpty()) {
             description.setId(UUID.randomUUID().toString());
             description.setStage(stage);
@@ -125,6 +126,20 @@ public class SourceDescriptionController extends BaseController {
                 section,
                 entityId,
                 extension);
+    }
+
+    private void sanitizeSourceDescription(SourceDescription description) {
+        description.setSourceType(trimToNull(description.getSourceType()));
+        description.setQuantity(trimToNull(description.getQuantity()));
+        description.setDescription(trimToNull(description.getDescription()));
+        description.setDimensions(trimToNull(description.getDimensions()));
+        description.setEncapsulationOrCladding(trimToNull(description.getEncapsulationOrCladding()));
+        description.setSerialNumber(trimToNull(description.getSerialNumber()));
+        description.setShippingHistory(trimToNull(description.getShippingHistory()));
+        description.setReceivingHistory(trimToNull(description.getReceivingHistory()));
+        description.setRadiographOrPhotograph(trimToNull(description.getRadiographOrPhotograph()));
+        description.setImageFile(trimToNull(description.getImageFile()));
+        description.setNotes(trimToNull(description.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/StableIsotopeController.java
+++ b/src/main/java/io/sci/nnfl/web/StableIsotopeController.java
@@ -33,6 +33,7 @@ public class StableIsotopeController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeIsotopeRatio(isotope);
         if (isotope.getId() == null || isotope.getId().isEmpty()) {
             isotope.setId(UUID.randomUUID().toString());
             isotope.setStage(Stage.values()[stage]);
@@ -50,6 +51,12 @@ public class StableIsotopeController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "stableIsotopes", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeIsotopeRatio(IsotopeRatio isotope) {
+        isotope.setName(trimToNull(isotope.getName()));
+        isotope.setUnit(trimToNull(isotope.getUnit()));
+        isotope.setNotes(trimToNull(isotope.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/TraceElementController.java
+++ b/src/main/java/io/sci/nnfl/web/TraceElementController.java
@@ -33,6 +33,7 @@ public class TraceElementController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeElement(element);
         if (element.getId() == null || element.getId().isEmpty()) {
             element.setId(UUID.randomUUID().toString());
             element.setStage(Stage.values()[stage]);
@@ -50,6 +51,13 @@ public class TraceElementController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "traceElements", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeElement(Element element) {
+        element.setElement(trimToNull(element.getElement()));
+        element.setUnit(trimToNull(element.getUnit()));
+        element.setBurnablePoison(trimToNull(element.getBurnablePoison()));
+        element.setNotes(trimToNull(element.getNotes()));
     }
 }
 

--- a/src/main/java/io/sci/nnfl/web/UraniumController.java
+++ b/src/main/java/io/sci/nnfl/web/UraniumController.java
@@ -33,6 +33,7 @@ public class UraniumController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeElement(element);
         if (element.getId() == null || element.getId().isEmpty()) {
             element.setId(UUID.randomUUID().toString());
             element.setStage(Stage.values()[stage]);
@@ -50,5 +51,12 @@ public class UraniumController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "uranium", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeElement(Element element) {
+        element.setElement(trimToNull(element.getElement()));
+        element.setUnit(trimToNull(element.getUnit()));
+        element.setBurnablePoison(trimToNull(element.getBurnablePoison()));
+        element.setNotes(trimToNull(element.getNotes()));
     }
 }

--- a/src/main/java/io/sci/nnfl/web/UraniumIsotopeController.java
+++ b/src/main/java/io/sci/nnfl/web/UraniumIsotopeController.java
@@ -33,6 +33,7 @@ public class UraniumIsotopeController extends BaseController {
         if (stage == null || stage < 0 || stage >= Stage.values().length) {
             return ResponseEntity.badRequest().body(Map.of("ok", false, "error", "Invalid stage"));
         }
+        sanitizeIsotopeRatio(isotope);
         if (isotope.getId() == null || isotope.getId().isEmpty()) {
             isotope.setId(UUID.randomUUID().toString());
             isotope.setStage(Stage.values()[stage]);
@@ -50,6 +51,12 @@ public class UraniumIsotopeController extends BaseController {
                          @PathVariable String id) {
         service.removeProperty(materialId, "uraniumIsotopes", id);
         return "redirect:/materials/" + materialId + "/" + stage;
+    }
+
+    private void sanitizeIsotopeRatio(IsotopeRatio isotope) {
+        isotope.setName(trimToNull(isotope.getName()));
+        isotope.setUnit(trimToNull(isotope.getUnit()));
+        isotope.setNotes(trimToNull(isotope.getNotes()));
     }
 }
 

--- a/src/main/resources/templates/material-form.html
+++ b/src/main/resources/templates/material-form.html
@@ -264,7 +264,7 @@
                 id: $('#chemicalId').val(),
                 stage: $('#chemicalStage').val() || stage,
                 compoundName: $('#chemicalName').val(),
-                stoichiometryDeviation: parseFloat($('#chemicalDeviation').val() || 0),
+                stoichiometryDeviation: parseDecimalOrNull($('#chemicalDeviation').val()),
                 notes: $('#chemicalComment').val()
             };
         });
@@ -293,9 +293,9 @@
                 id: $('#uraniumId').val(),
                 stage: $('#uraniumStage').val() || stage,
                 element: $('#uraniumName').val(),
-                concentration: parseFloat($('#uraniumConcentration').val() || 0),
+                concentration: parseDecimalOrNull($('#uraniumConcentration').val()),
                 unit: $('#uraniumUnit').val(),
-                uncertainty: parseFloat($('#uraniumUncertainty').val() || 0),
+                uncertainty: parseDecimalOrNull($('#uraniumUncertainty').val()),
                 burnablePoison: $('#uraniumBurnablePoison').val(),
                 notes: $('#uraniumComment').val()
             };
@@ -323,8 +323,8 @@
                 id: $('#uraniumIsotopeId').val(),
                 stage: $('#uraniumIsotopeStage').val() || stage,
                 name: $('#uraniumIsotopeName').val(),
-                value: parseFloat($('#uraniumIsotopeRatio').val() || 0),
-                uncertainty: parseFloat($('#uraniumIsotopeUncertainty').val() || 0),
+                value: parseDecimalOrNull($('#uraniumIsotopeRatio').val()),
+                uncertainty: parseDecimalOrNull($('#uraniumIsotopeUncertainty').val()),
                 unit: $('#uraniumIsotopeUnit').val(),
                 notes: $('#uraniumIsotopeComment').val()
             };
@@ -352,8 +352,8 @@
                 id: $('#stableIsotopeId').val(),
                 stage: $('#stableIsotopeStage').val() || stage,
                 name: $('#stableIsotopeName').val(),
-                value: parseFloat($('#stableIsotopeRatio').val() || 0),
-                uncertainty: parseFloat($('#stableIsotopeUncertainty').val() || 0),
+                value: parseDecimalOrNull($('#stableIsotopeRatio').val()),
+                uncertainty: parseDecimalOrNull($('#stableIsotopeUncertainty').val()),
                 unit: $('#stableIsotopeUnit').val(),
                 notes: $('#stableIsotopeComment').val()
             };
@@ -381,8 +381,8 @@
                 id: $('#plutoniumIsotopeId').val(),
                 stage: $('#plutoniumIsotopeStage').val() || stage,
                 name: $('#plutoniumIsotopeName').val(),
-                value: parseFloat($('#plutoniumIsotopeRatio').val() || 0),
-                uncertainty: parseFloat($('#plutoniumIsotopeUncertainty').val() || 0),
+                value: parseDecimalOrNull($('#plutoniumIsotopeRatio').val()),
+                uncertainty: parseDecimalOrNull($('#plutoniumIsotopeUncertainty').val()),
                 unit: $('#plutoniumIsotopeUnit').val(),
                 notes: $('#plutoniumIsotopeComment').val()
             };
@@ -410,9 +410,9 @@
                 id: $('#traceElementId').val(),
                 stage: $('#traceElementStage').val() || stage,
                 element: $('#traceElementName').val(),
-                concentration: parseFloat($('#traceElementConcentration').val() || 0),
+                concentration: parseDecimalOrNull($('#traceElementConcentration').val()),
                 unit: $('#traceElementUnit').val(),
-                uncertainty: parseFloat($('#traceElementUncertainty').val() || 0),
+                uncertainty: parseDecimalOrNull($('#traceElementUncertainty').val()),
                 notes: $('#traceElementComment').val()
             };
         });
@@ -442,9 +442,9 @@
                 id: $('#elementId').val(),
                 stage: $('#elementStage').val() || stage,
                 element: $('#elementName').val(),
-                concentration: parseFloat($('#elementConcentration').val() || 0),
+                concentration: parseDecimalOrNull($('#elementConcentration').val()),
                 unit: $('#elementUnit').val(),
-                uncertainty: parseFloat($('#elementUncertainty').val() || 0),
+                uncertainty: parseDecimalOrNull($('#elementUncertainty').val()),
                 burnablePoison: $('#elementBurnablePoison').val(),
                 notes: $('#elementComment').val()
             };
@@ -533,8 +533,8 @@
                 id: $('#uraniumDecayId').val(),
                 stage: $('#uraniumDecayStage').val() || stage,
                 isotopeName: $('#uraniumDecayNuclide').val(),
-                activityBq: parseFloat($('#uraniumDecayActivity').val() || 0),
-                activityUncertaintyBq: parseFloat($('#uraniumDecayUncertainty').val() || 0),
+                activityBq: parseDecimalOrNull($('#uraniumDecayActivity').val()),
+                activityUncertaintyBq: parseDecimalOrNull($('#uraniumDecayUncertainty').val()),
                 notes: $('#uraniumDecayComment').val()
             };
         });
@@ -562,7 +562,7 @@
                 id: $('#containerId').val(),
                 stage: $('#containerStage').val() || stage,
                 type: $('#containerType').val(),
-                volumeValue: parseFloat($('#containerVolume').val() || 0),
+                volumeValue: parseDecimalOrNull($('#containerVolume').val()),
                 volumeUnit: $('#containerUnit').val(),
                 dimensions: $('#containerDimensions').val(),
                 notes: $('#containerNotes').val()
@@ -753,8 +753,8 @@
                 id: $('#isotopeActivityId').val(),
                 stage: $('#isotopeActivityStage').val() || stage,
                 isotopeName: $('#isotopeActivityName').val(),
-                activityBq: parseFloat($('#isotopeActivityValue').val() || 0),
-                activityUncertaintyBq: parseFloat($('#isotopeActivityUncertainty').val() || 0),
+                activityBq: parseDecimalOrNull($('#isotopeActivityValue').val()),
+                activityUncertaintyBq: parseDecimalOrNull($('#isotopeActivityUncertainty').val()),
                 referenceDate: $('#isotopeActivityDate').val(),
                 major: $('#isotopeActivityMajor').is(':checked'),
                 notes: $('#isotopeActivityNotes').val()
@@ -782,7 +782,7 @@
                 stage: $('#mineralogyStage').val() || stage,
                 mineralsPresent: $('#mineralogyMinerals').val(),
                 mineralChemistry: $('#mineralogyChemistry').val(),
-                volumePercentages: parseFloat($('#mineralogyVolume').val() || 0),
+                volumePercentages: parseDecimalOrNull($('#mineralogyVolume').val()),
                 notes: $('#mineralogyNotes').val()
             };
         });
@@ -827,7 +827,7 @@
             return {
                 id: $('#physicalId').val(),
                 stage: $('#physicalStage').val() || stage,
-                densityValue: parseFloat($('#physicalDensityValue').val() || 0),
+                densityValue: parseDecimalOrNull($('#physicalDensityValue').val()),
                 densityUnit: $('#physicalDensityUnit').val(),
                 stateOfMatter: $('#physicalState').val(),
                 mechanicalProperties: $('#physicalMechanical').val(),
@@ -837,7 +837,7 @@
                 coatingInfo: $('#physicalCoating').val(),
                 assemblyStructure: $('#physicalAssembly').val(),
                 surfaceOxideThickness: $('#physicalOxide').val(),
-                massValue: parseFloat($('#physicalMassValue').val() || 0),
+                massValue: parseDecimalOrNull($('#physicalMassValue').val()),
                 massUnit: $('#physicalMassUnit').val(),
                 serialNumbers: $('#physicalSerialNumbers').val(),
                 notes: $('#physicalNotes').val()
@@ -917,9 +917,9 @@
             return {
                 id: $('#sourceActivityId').val(),
                 stage: $('#sourceActivityStage').val() || stage,
-                activityBq: parseFloat($('#sourceActivityValue').val() || 0),
+                activityBq: parseDecimalOrNull($('#sourceActivityValue').val()),
                 referenceDate: $('#sourceActivityDate').val(),
-                neutronIntensityPerSec: parseFloat($('#sourceActivityNeutron').val() || 0),
+                neutronIntensityPerSec: parseDecimalOrNull($('#sourceActivityNeutron').val()),
                 notes: $('#sourceActivityNotes').val()
             };
         });


### PR DESCRIPTION
## Summary
- trim and sanitize string fields before persistence across material section controllers
- use `parseDecimalOrNull` on material form numeric inputs so invalid values remain null instead of defaulting to zero

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve Spring Boot parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d128c83c9c833383b28557b4ea926a